### PR TITLE
fix: fix hashRouter link path

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -11,7 +11,7 @@ function HomePage() {
             {section.articles.map((article) => (
               <li key={article.path}>
                 <Link
-                  to={article.path.substring(1)} // Remove leading '#' for Link component
+                  to={article.path} // Use the full hash path
                   className="text-blue-600 hover:text-blue-800 hover:underline"
                 >
                   {article.name}


### PR DESCRIPTION
`src/pages/HomePage.tsx` において、`HashRouter` を使用しているにも関わらず、`Link` コンポーネントに渡されるパスから `#` が削除されていたため、リンクが正しく機能しない問題を修正しました。

`article.path` を直接 `to` プロパティに渡すように変更しました。