### PR TITLE
feat: introduce shadcn/ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ help:
 	@echo "  --- Initial Setup (Run only once if needed) ---"
 	@echo "  make init-vite    Initialize Vite project in current dir (Use with caution!)"
 	@echo "  make init-tailwind Initialize Tailwind CSS config (Use with caution!)"
+	@echo "  make init-shadcn   Initialize shadcn/ui (Use with caution!)"
 
 # Install dependencies
 .PHONY: install
@@ -62,6 +63,13 @@ init-vite:
 init-tailwind:
 	@echo "WARNING: This will create/overwrite Tailwind CSS config files."
 	bunx tailwindcss init -p
+
+# Initialize shadcn/ui (Run only if not already initialized)
+.PHONY: init-shadcn
+init-shadcn:
+	@echo "WARNING: This will initialize shadcn/ui and may overwrite existing configurations."
+	@echo "Ensure tsconfig.json has baseUrl and paths configured."
+	bunx shadcn@latest init
 
 .PHONY: br-clean
 br-clean:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,28 @@
         # make init-tailwind # または bunx tailwindcss init -p
         ```
 
-3.  **依存関係のインストール:**
+3.  **shadcn/ui の導入 (必要な場合のみ):**
+    *   **注意:** このリポジトリには既に shadcn/ui が導入されています。新規に導入する場合や、設定ファイルが失われた場合にのみ以下のコマンドを実行してください。
+    *   `tsconfig.json` に `baseUrl` と `paths` が設定されていることを確認してください（shadcn/ui はインポートエイリアスを必要とします）。
+        ```json
+        // tsconfig.json (抜粋)
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "@/*": ["./src/*"]
+            }
+            // ...
+          }
+        }
+        ```
+    *   shadcn/ui CLI を使用して初期化します。対話形式で設定を選択します。
+        ```bash
+        # make init-shadcn # または bunx shadcn@latest init
+        ```
+
+4.  **依存関係のインストール:**
+    *   shadcn/ui の初期化時に依存関係がインストールされますが、手動でインストールする場合は以下を実行します。
     ```bash
     bun install
     ```
@@ -40,7 +61,7 @@
     make install
     ```
 
-4.  **開発サーバーの起動:**
+5.  **開発サーバーの起動:**
     ```bash
     bun run dev
     ```
@@ -50,7 +71,7 @@
     ```
     ブラウザで `http://localhost:5173` (または表示されたポート) を開きます。
 
-5.  **静的ファイルのビルド:**
+6.  **静的ファイルのビルド:**
     ```bash
     bun run build
     ```
@@ -69,6 +90,8 @@
 ├── src/                      # アプリケーションソースコード
 │   ├── data/                 # データファイル (記事情報など)
 │   │   └── markdownFiles.ts
+│   ├── lib/                  # shadcn/ui ユーティリティ
+│   │   └── utils.ts
 │   ├── pages/                # ページコンポーネント
 │   │   └── HomePage.tsx
 │   ├── App.tsx               # ルートコンポーネント、ルーティング設定
@@ -78,7 +101,8 @@
 ├── .gitignore
 ├── bun.lockb
 ├── index.html                # HTML エントリーポイント
-├── Makefile                  # ビルド/開発用コマンド
+├── Makefile                  # ビルド/開発/初期化用コマンド
+├── components.json           # shadcn/ui 設定
 ├── package.json
 ├── postcss.config.js
 ├── tailwind.config.js

--- a/bun.lock
+++ b/bun.lock
@@ -4,11 +4,16 @@
     "": {
       "name": "tailwindcss-text-docs",
       "dependencies": {
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.485.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.23.1",
         "remark-gfm": "^4.0.1",
+        "tailwind-merge": "^3.0.2",
+        "tailwindcss-animate": "^1.0.7",
       },
       "devDependencies": {
         "@types/react": "^18.2.66",
@@ -299,6 +304,10 @@
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
+    "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -496,6 +505,8 @@
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lucide-react": ["lucide-react@0.485.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-NvyQJ0LKyyCxL23nPKESlr/jmz8r7fJO1bkuptSNYSy0s8VVj4ojhX0YAgmE1e0ewfxUZjIlZpvH+otfTnla8Q=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
@@ -741,7 +752,11 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "tailwind-merge": ["tailwind-merge@3.0.2", "", {}, "sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw=="],
+
     "tailwindcss": ["tailwindcss@3.4.17", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.6", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og=="],
+
+    "tailwindcss-animate": ["tailwindcss-animate@1.0.7", "", { "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders" } }, "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA=="],
 
     "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
 

--- a/components.json
+++ b/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/index.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/package.json
+++ b/package.json
@@ -10,11 +10,16 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.485.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.23.1",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "tailwind-merge": "^3.0.2",
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/src/index.css
+++ b/src/index.css
@@ -5,46 +5,62 @@
 @layer base {
   :root {
     --background: 0 0% 100%; /* white */
-    --foreground: 222.2 84% 4.9%; /* ~gray-950 */
+    --foreground: 0 0% 3.9%; /* ~gray-950 */
     --card: 0 0% 100%; /* white */
-    --card-foreground: 222.2 84% 4.9%; /* ~gray-950 */
+    --card-foreground: 0 0% 3.9%; /* ~gray-950 */
     --popover: 0 0% 100%; /* white */
-    --popover-foreground: 222.2 84% 4.9%; /* ~gray-950 */
-    --primary: 200.4 98.1% 39.2%; /* ~sky-500 */
-    --primary-foreground: 210 40% 98%; /* white */
-    --secondary: 210 40% 96.1%; /* gray-100 */
-    --secondary-foreground: 222.2 47.4% 11.2%; /* gray-900 */
-    --muted: 210 40% 96.1%; /* gray-100 */
-    --muted-foreground: 215.4 16.3% 46.9%; /* gray-500 */
-    --accent: 210 40% 96.1%; /* gray-100 */
-    --accent-foreground: 222.2 47.4% 11.2%; /* gray-900 */
+    --popover-foreground: 0 0% 3.9%; /* ~gray-950 */
+    --primary: 0 0% 9%; /* ~sky-500 */
+    --primary-foreground: 0 0% 98%; /* white */
+    --secondary: 0 0% 96.1%; /* gray-100 */
+    --secondary-foreground: 0 0% 9%; /* gray-900 */
+    --muted: 0 0% 96.1%; /* gray-100 */
+    --muted-foreground: 0 0% 45.1%; /* gray-500 */
+    --accent: 0 0% 96.1%; /* gray-100 */
+    --accent-foreground: 0 0% 9%; /* gray-900 */
     --destructive: 0 84.2% 60.2%; /* red-500 */
-    --destructive-foreground: 210 40% 98%; /* white */
-    --border: 214.3 31.8% 91.4%; /* gray-200 */
-    --input: 214.3 31.8% 91.4%; /* gray-200 */
-    --ring: 200.4 98.1% 39.2%; /* ~sky-500 */
+    --destructive-foreground: 0 0% 98%; /* white */
+    --border: 0 0% 89.8%; /* gray-200 */
+    --input: 0 0% 89.8%; /* gray-200 */
+    --ring: 0 0% 3.9%; /* ~sky-500 */
     --radius: 0.5rem;
+    --chart-1: 12 76% 61%;
+    --chart-2: 173 58% 39%;
+    --chart-3: 197 37% 24%;
+    --chart-4: 43 74% 66%;
+    --chart-5: 27 87% 67%;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%; /* ~gray-950 */
-    --foreground: 210 40% 98%; /* ~gray-50 */
-    --card: 222.2 84% 4.9%; /* ~gray-950 */
-    --card-foreground: 210 40% 98%; /* ~gray-50 */
-    --popover: 222.2 84% 4.9%; /* ~gray-950 */
-    --popover-foreground: 210 40% 98%; /* ~gray-50 */
-    --primary: 200.4 98.1% 39.2%; /* ~sky-500 */
-    --primary-foreground: 210 40% 98%; /* white */
-    --secondary: 217.2 32.6% 17.5%; /* gray-800 */
-    --secondary-foreground: 210 40% 98%; /* gray-50 */
-    --muted: 217.2 32.6% 17.5%; /* gray-800 */
-    --muted-foreground: 215 20.2% 65.1%; /* gray-400 */
-    --accent: 217.2 32.6% 17.5%; /* gray-800 */
-    --accent-foreground: 210 40% 98%; /* gray-50 */
+    --background: 0 0% 3.9%; /* ~gray-950 */
+    --foreground: 0 0% 98%; /* ~gray-50 */
+    --card: 0 0% 3.9%; /* ~gray-950 */
+    --card-foreground: 0 0% 98%; /* ~gray-50 */
+    --popover: 0 0% 3.9%; /* ~gray-950 */
+    --popover-foreground: 0 0% 98%; /* ~gray-50 */
+    --primary: 0 0% 98%; /* ~sky-500 */
+    --primary-foreground: 0 0% 9%; /* white */
+    --secondary: 0 0% 14.9%; /* gray-800 */
+    --secondary-foreground: 0 0% 98%; /* gray-50 */
+    --muted: 0 0% 14.9%; /* gray-800 */
+    --muted-foreground: 0 0% 63.9%; /* gray-400 */
+    --accent: 0 0% 14.9%; /* gray-800 */
+    --accent-foreground: 0 0% 98%; /* gray-50 */
     --destructive: 0 62.8% 30.6%; /* red-900 */
-    --destructive-foreground: 210 40% 98%; /* white */
-    --border: 217.2 32.6% 17.5%; /* gray-800 */
-    --input: 217.2 32.6% 17.5%; /* gray-800 */
-    --ring: 200.4 98.1% 39.2%; /* ~sky-500 */
+    --destructive-foreground: 0 0% 98%; /* white */
+    --border: 0 0% 14.9%; /* gray-800 */
+    --input: 0 0% 14.9%; /* gray-800 */
+    --ring: 0 0% 83.1%; /* ~sky-500 */ --chart-1: 220 70% 50%; --chart-2: 160 60% 45%; --chart-3: 30 80% 55%; --chart-4: 280 65% 60%; --chart-5: 340 75% 55%;
+  }
+}
+
+
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
   }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,48 +3,55 @@ export default {
   darkMode: 'class', // ダークモードをクラスベースで有効化
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {
-      colors: {
-        border: 'hsl(var(--border))', // ボーダー色
-        input: 'hsl(var(--input))', // 入力欄ボーダー色
-        ring: 'hsl(var(--ring))', // フォーカスリング色
-        background: 'hsl(var(--background))', // 背景色
-        foreground: 'hsl(var(--foreground))', // 前景色 (テキストなど)
-        primary: {
-          DEFAULT: 'hsl(var(--primary))', // プライマリ色 (アクセント、リンクなど)
-          foreground: 'hsl(var(--primary-foreground))', // プライマリ色上のテキスト色
-        },
-        secondary: { // 必要に応じて定義
-          DEFAULT: 'hsl(var(--secondary))',
-          foreground: 'hsl(var(--secondary-foreground))',
-        },
-        destructive: { // 必要に応じて定義 (エラー表示など)
-          DEFAULT: 'hsl(var(--destructive))',
-          foreground: 'hsl(var(--destructive-foreground))',
-        },
-        muted: { // 補助的な要素
-          DEFAULT: 'hsl(var(--muted))', // ミュート背景
-          foreground: 'hsl(var(--muted-foreground))', // ミュート前景 (補助テキスト)
-        },
-        accent: { // 必要に応じて定義 (強調など)
-          DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))',
-        },
-        popover: { // ポップオーバー用
-          DEFAULT: 'hsl(var(--popover))',
-          foreground: 'hsl(var(--popover-foreground))',
-        },
-        card: { // カードコンポーネント用
-          DEFAULT: 'hsl(var(--card))', // カード背景
-          foreground: 'hsl(var(--card-foreground))', // カード前景
-        },
-      },
-      borderRadius: { // 例として追加
-        lg: 'var(--radius)',
-        md: 'calc(var(--radius) - 2px)',
-        sm: 'calc(var(--radius) - 4px)',
-      }
-    },
+  	extend: {
+  		colors: {
+  			border: 'hsl(var(--border))',
+  			input: 'hsl(var(--input))',
+  			ring: 'hsl(var(--ring))',
+  			background: 'hsl(var(--background))',
+  			foreground: 'hsl(var(--foreground))',
+  			primary: {
+  				DEFAULT: 'hsl(var(--primary))',
+  				foreground: 'hsl(var(--primary-foreground))'
+  			},
+  			secondary: {
+  				DEFAULT: 'hsl(var(--secondary))',
+  				foreground: 'hsl(var(--secondary-foreground))'
+  			},
+  			destructive: {
+  				DEFAULT: 'hsl(var(--destructive))',
+  				foreground: 'hsl(var(--destructive-foreground))'
+  			},
+  			muted: {
+  				DEFAULT: 'hsl(var(--muted))',
+  				foreground: 'hsl(var(--muted-foreground))'
+  			},
+  			accent: {
+  				DEFAULT: 'hsl(var(--accent))',
+  				foreground: 'hsl(var(--accent-foreground))'
+  			},
+  			popover: {
+  				DEFAULT: 'hsl(var(--popover))',
+  				foreground: 'hsl(var(--popover-foreground))'
+  			},
+  			card: {
+  				DEFAULT: 'hsl(var(--card))',
+  				foreground: 'hsl(var(--card-foreground))'
+  			},
+  			chart: {
+  				'1': 'hsl(var(--chart-1))',
+  				'2': 'hsl(var(--chart-2))',
+  				'3': 'hsl(var(--chart-3))',
+  				'4': 'hsl(var(--chart-4))',
+  				'5': 'hsl(var(--chart-5))'
+  			}
+  		},
+  		borderRadius: {
+  			lg: 'var(--radius)',
+  			md: 'calc(var(--radius) - 2px)',
+  			sm: 'calc(var(--radius) - 4px)'
+  		}
+  	}
   },
-  plugins: [],
+  plugins: [require("tailwindcss-animate")],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,12 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    },
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -6,7 +6,6 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "strict": true,
-    "noEmit": true, // tsconfig.json で noEmit: true なのでこちらも合わせる
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo" // ビルド情報ファイル
   },
   "include": ["vite.config.ts"] // vite.config.ts を対象とする


### PR DESCRIPTION
shadcn/ui をプロジェクトに導入し、基本的なセットアップを行いました。

**主な変更点:**

*   `bunx shadcn@latest init` を実行し、shadcn/ui を初期化 (Style: New York, Base Color: Neutral)
*   `components.json` を新規作成
*   `tailwind.config.js` を更新 (テーマ設定、プラグイン追加、`darkMode` を `'class'` に修正)
*   `src/index.css` を更新 (CSS 変数定義)
*   `tsconfig.json` を更新 (インポートエイリアス `@/*` を追加)
*   `tsconfig.node.json` を更新 (`noEmit: true` を削除)
*   `src/lib/utils.ts` を新規作成
*   必要な依存関係 (`tailwindcss-animate`, `class-variance-authority`, `clsx`, `lucide-react` など) をインストール
*   `README.md` と `Makefile` に shadcn/ui の導入手順を追記

Closes: #10