### PR TITLE
feat: Implement SEO enhancements for GitHub Pages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "lucide-react": "^0.486.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-helmet-async": "^2.0.5",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.4.1",
         "remark-gfm": "^4.0.1",
@@ -37,6 +38,7 @@
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.24.1",
         "vite": "^6.2.0",
+        "vite-plugin-sitemap": "^0.7.1",
       },
     },
   },
@@ -445,6 +447,8 @@
 
     "inline-style-parser": ["inline-style-parser@0.2.4", "", {}, "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="],
 
+    "invariant": ["invariant@2.2.4", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA=="],
+
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
@@ -498,6 +502,8 @@
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "lovable-tagger": ["lovable-tagger@1.1.8", "", { "dependencies": { "@babel/parser": "^7.25.9", "@babel/types": "^7.25.8", "esbuild": "^0.25.0", "estree-walker": "^3.0.3", "magic-string": "^0.30.12", "tailwindcss": "^3.4.17" }, "peerDependencies": { "vite": "^5.0.0" } }, "sha512-0a8lEpsgk+Z6crd+HE+GTmVzB0f++lMyTgW3QUF+hYZBjsA384RqUfCZAYccHlMLxYPI+dk7zjVuIvJcq8PiBg=="],
 
@@ -677,6 +683,10 @@
 
     "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
 
+    "react-fast-compare": ["react-fast-compare@3.2.2", "", {}, "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="],
+
+    "react-helmet-async": ["react-helmet-async@2.0.5", "", { "dependencies": { "invariant": "^2.2.4", "react-fast-compare": "^3.2.2", "shallowequal": "^1.1.0" }, "peerDependencies": { "react": "^16.6.0 || ^17.0.0 || ^18.0.0" } }, "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg=="],
+
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
     "react-router": ["react-router@7.4.1", "", { "dependencies": { "@types/cookie": "^0.6.0", "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0", "turbo-stream": "2.4.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-Vmizn9ZNzxfh3cumddqv3kLOKvc7AskUT0dC1prTabhiEi0U4A33LmkDOJ79tXaeSqCqMBXBU/ySX88W85+EUg=="],
@@ -710,6 +720,8 @@
     "semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
 
     "set-cookie-parser": ["set-cookie-parser@2.7.1", "", {}, "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="],
+
+    "shallowequal": ["shallowequal@1.1.0", "", {}, "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -796,6 +808,8 @@
     "vfile-message": ["vfile-message@4.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw=="],
 
     "vite": ["vite@6.2.4", "", { "dependencies": { "esbuild": "^0.25.0", "postcss": "^8.5.3", "rollup": "^4.30.1" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw=="],
+
+    "vite-plugin-sitemap": ["vite-plugin-sitemap@0.7.1", "", {}, "sha512-4NRTkiWytLuAmcikckrLcLl9iYA20+5v6l8XshcOrzxH1WR8H0O3S6sTQYfjMrE8su/LG6Y0cTodvOdcOIxaLw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/index.html
+++ b/index.html
@@ -8,8 +8,20 @@
     <meta name="description" content="Tailwind CSSの全ユーティリティクラスを日本語で解説。クラス名、プロパティ、値を網羅したリファレンスサイトです。" />
     <meta name="keywords" content="Tailwind CSS, CSS, ユーティリティクラス, 日本語, リファレンス, チートシート, フロントエンド, Web開発" />
     <title>Tailwind CSS 日本語解説</title>
+    <meta name="google-site-verification" content="X5Ntrn-UPDc7BSuNsbg-8km5JssAost8S-vp-WKq4ys" />
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-M9HS2DQL');</script>
+    <!-- End Google Tag Manager -->
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M9HS2DQL"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "^0.486.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-helmet-async": "^2.0.5",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.4.1",
     "remark-gfm": "^4.0.1",
@@ -44,6 +45,7 @@
     "tailwindcss": "3",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vite-plugin-sitemap": "^0.7.1"
   }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Allow: /
+Sitemap: https://tKwbr999.github.io/tailwindcss-text/sitemap.xml

--- a/scripts/add-meta-tags.mjs
+++ b/scripts/add-meta-tags.mjs
@@ -1,0 +1,121 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { glob } from 'glob';
+
+const pagesDir = path.resolve('src/pages');
+const targetPattern = path.join(pagesDir, '**/*-page.tsx').replace(/\\/g, '/'); // globはスラッシュ区切りを期待
+const excludePatterns = [
+  path.join(pagesDir, 'HomePage.tsx').replace(/\\/g, '/'),
+  path.join(pagesDir, 'ArticlePage.tsx').replace(/\\/g, '/'), // ArticlePageも除外（存在する場合）
+];
+const baseUrl = 'https://tKwbr999.github.io/tailwindcss-text/#'; // GitHub PagesのベースURL + HashRouter
+
+async function addMetaTags() {
+  console.log(`Searching for files matching: ${targetPattern}`);
+  const files = await glob(targetPattern, { ignore: excludePatterns });
+  console.log(`Found ${files.length} files to process.`);
+
+  let modifiedCount = 0;
+  let skippedCount = 0;
+
+  for (const file of files) {
+    const relativePath = path.relative(process.cwd(), file).replace(/\\/g, '/');
+    console.log(`\nProcessing: ${relativePath}`);
+    try {
+      let content = await fs.readFile(file, 'utf-8');
+      let importAdded = false;
+      let helmetAdded = false;
+
+      // 1. Check if Helmet is already imported
+      if (!/import .*\{.*Helmet.*\}.* from 'react-helmet-async'/.test(content)) {
+        // Add import statement if not found
+        content = `import { Helmet } from 'react-helmet-async'; // Helmet をインポート\n${content}`;
+        importAdded = true;
+        console.log('  - Added Helmet import.');
+      } else {
+        console.log('  - Helmet import already exists.');
+      }
+
+      // 2. Check if <Helmet> tag already exists
+      if (/<Helmet>/.test(content)) {
+        console.log('  - <Helmet> tag already exists. Skipping.');
+        skippedCount++;
+        continue; // Skip if Helmet tag is already present
+      }
+
+      // 3. Extract title from ArticleLayout or generate from filename
+      let pageTitle = 'Tailwind CSS Cheatsheet'; // Default title
+      const titleMatch = content.match(/<ArticleLayout\s+title="([^"]+)"/);
+      if (titleMatch && titleMatch[1]) {
+        pageTitle = titleMatch[1].replace(/\s*\(.*\)/, ''); // Remove Japanese part like (アスペクト比)
+        console.log(`  - Extracted title from ArticleLayout: "${pageTitle}"`);
+      } else {
+        // Generate title from filename if not found in ArticleLayout
+        const filename = path.basename(file, '-page.tsx');
+        pageTitle = filename
+          .split('-')
+          .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+          .join(' ');
+        console.log(`  - Generated title from filename: "${pageTitle}"`);
+      }
+      const fullTitle = `${pageTitle} - Tailwind CSS Cheatsheet`;
+
+      // 4. Generate description and URL
+      const defaultDescription = `Learn about the ${pageTitle} utility in Tailwind CSS. Examples and usage details for ${pageTitle}.`;
+      const urlPath = file
+        .replace(pagesDir, '')
+        .replace(/\\/g, '/') // Ensure forward slashes
+        .replace(/-page\.tsx$/, '');
+      const pageUrl = `${baseUrl}${urlPath}`;
+      console.log(`  - Generated URL: ${pageUrl}`);
+
+      // 5. Generate Helmet component string
+      const helmetString = `
+      <Helmet>
+        <title>${fullTitle}</title>
+        <meta name="description" content="${defaultDescription}" />
+        {/* OGP タグ */}
+        <meta property="og:title" content="${fullTitle}" />
+        <meta property="og:description" content="${defaultDescription}" />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="${pageUrl}" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>`;
+
+      // 6. Find insertion point (after <ArticleLayout ... > tag)
+      const insertionMatch = content.match(/(<ArticleLayout[^>]*>)/);
+      if (insertionMatch && insertionMatch.index !== undefined) {
+        const insertionIndex = insertionMatch.index + insertionMatch[0].length;
+        content = `${content.slice(0, insertionIndex)}\n${helmetString}${content.slice(insertionIndex)}`;
+        helmetAdded = true;
+        console.log('  - Inserted <Helmet> tag.');
+      } else {
+        console.log('  - Could not find insertion point (<ArticleLayout> tag). Skipping Helmet insertion.');
+        // If import was added but Helmet wasn't, revert the import addition
+        if (importAdded) {
+           content = content.replace("import { Helmet } from 'react-helmet-async'; // Helmet をインポート\n", "");
+           console.log('  - Reverted Helmet import addition.');
+        }
+        skippedCount++;
+        continue;
+      }
+
+      // 7. Write changes back to file
+      if (helmetAdded) {
+        await fs.writeFile(file, content, 'utf-8');
+        modifiedCount++;
+        console.log('  - Successfully modified file.');
+      }
+
+    } catch (error) {
+      console.error(`  - Error processing file ${relativePath}:`, error);
+      skippedCount++;
+    }
+  }
+
+  console.log(`\nFinished processing.`);
+  console.log(`  - Modified files: ${modifiedCount}`);
+  console.log(`  - Skipped files: ${skippedCount}`);
+}
+
+addMetaTags();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'; // Reactフック
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 
 import { Routes, Route } from 'react-router-dom'; // ルーティング用コンポーネント
 import { useLocation } from 'react-router-dom'; // ルーティング用フック
@@ -54,6 +55,13 @@ function App() {
   return (
     // 全体のコンテナ、左右に自動マージン、上下左右にパディング
     <div className="container mx-auto p-4">
+      {/* デフォルトのメタ情報を設定 */}
+      <Helmet>
+        <title>Tailwind CSS Text Utilities Cheatsheet</title>
+        <meta name="description" content="A comprehensive cheatsheet for Tailwind CSS text-related utility classes. Find examples for typography, spacing, alignment, decoration, and more." />
+        {/* 必要に応じて他のデフォルトメタタグ（言語指定など）を追加 */}
+        {/* <html lang="ja" /> */}
+      </Helmet>
       {/* 各ページのコンテンツを表示するメインエリア */}
       <main>
         {/* ルーティング設定 */}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 // HashRouter を使用して GitHub Pages での静的ホスティングに対応
 import { HashRouter } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async'; // HelmetProvider をインポート
 import './index.css'; // グローバル CSS (Tailwind ディレクティブを含む)
 import App from './App.tsx'; // ルートコンポーネント
 
@@ -20,7 +21,9 @@ const root = createRoot(rootElement);
 root.render(
   <StrictMode> {/* 潜在的な問題を検出するための StrictMode */}
     <HashRouter> {/* ルーティング機能を提供 */}
-      <App /> {/* アプリケーション本体 */}
+      <HelmetProvider> {/* HelmetProvider で App をラップ */}
+        <App /> {/* アプリケーション本体 */}
+      </HelmetProvider>
     </HashRouter>
   </StrictMode>
 );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'; // useState フックをインポート
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import { Link } from 'react-router-dom';
 import { sections } from '../data/markdownFiles'; // データファイルをインポート
 
@@ -30,6 +31,18 @@ function HomePage() {
   return (
     // ページ全体に背景色とパディング (もう一段暗く)
     <div className="bg-stone-200 dark:bg-stone-900 min-h-screen p-4 md:p-8 font-serif">
+      <Helmet>
+        {/* ページタイトル: App.tsx のデフォルトを上書き */}
+        <title>Tailwind CSS Utilities Cheatsheet - Home</title>
+        {/* ページの説明: App.tsx のデフォルトを上書き */}
+        <meta name="description" content="Explore all Tailwind CSS utility classes with examples. Find sections for layout, flexbox, grid, spacing, typography, and more." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Tailwind CSS Utilities Cheatsheet - Home" />
+        <meta property="og:description" content="Explore all Tailwind CSS utility classes with examples. Find sections for layout, flexbox, grid, spacing, typography, and more." />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       {' '}
       {/* bg-stone-100 を bg-stone-200 に変更 */}
       {/* コンテナ: 最大幅、中央揃え、背景色、角丸、影 */}

--- a/src/pages/accessibility/screen-readers-page.tsx
+++ b/src/pages/accessibility/screen-readers-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -169,6 +170,17 @@ const ScreenReadersPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Screen Readers - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Screen Readers utility in Tailwind CSS. Examples and usage details for Screen Readers." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Screen Readers - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Screen Readers utility in Tailwind CSS. Examples and usage details for Screen Readers." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/accessibility/screen-readers" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       {content}
     </ArticleLayout>
   );

--- a/src/pages/backgrounds/background-attachment-page.tsx
+++ b/src/pages/backgrounds/background-attachment-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -104,6 +105,17 @@ const BackgroundAttachmentPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Background Attachment - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Background Attachment utility in Tailwind CSS. Examples and usage details for Background Attachment." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Background Attachment - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Background Attachment utility in Tailwind CSS. Examples and usage details for Background Attachment." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/backgrounds/background-attachment" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/backgrounds/background-clip-page.tsx
+++ b/src/pages/backgrounds/background-clip-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -70,6 +71,17 @@ const BackgroundClipPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Background Clip - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Background Clip utility in Tailwind CSS. Examples and usage details for Background Clip." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Background Clip - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Background Clip utility in Tailwind CSS. Examples and usage details for Background Clip." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/backgrounds/background-clip" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/backgrounds/background-color-page.tsx
+++ b/src/pages/backgrounds/background-color-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -87,6 +88,17 @@ const BackgroundColorPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Background Color - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Background Color utility in Tailwind CSS. Examples and usage details for Background Color." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Background Color - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Background Color utility in Tailwind CSS. Examples and usage details for Background Color." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/backgrounds/background-color" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/backgrounds/background-image-page.tsx
+++ b/src/pages/backgrounds/background-image-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -83,6 +84,17 @@ const BackgroundImagePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Background Image - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Background Image utility in Tailwind CSS. Examples and usage details for Background Image." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Background Image - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Background Image utility in Tailwind CSS. Examples and usage details for Background Image." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/backgrounds/background-image" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/backgrounds/background-origin-page.tsx
+++ b/src/pages/backgrounds/background-origin-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -68,6 +69,17 @@ const BackgroundOriginPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Background Origin - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Background Origin utility in Tailwind CSS. Examples and usage details for Background Origin." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Background Origin - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Background Origin utility in Tailwind CSS. Examples and usage details for Background Origin." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/backgrounds/background-origin" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/backgrounds/background-position-page.tsx
+++ b/src/pages/backgrounds/background-position-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -107,6 +108,17 @@ const BackgroundPositionPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Background Position - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Background Position utility in Tailwind CSS. Examples and usage details for Background Position." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Background Position - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Background Position utility in Tailwind CSS. Examples and usage details for Background Position." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/backgrounds/background-position" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/backgrounds/background-repeat-page.tsx
+++ b/src/pages/backgrounds/background-repeat-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -120,6 +121,17 @@ const BackgroundRepeatPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Background Repeat - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Background Repeat utility in Tailwind CSS. Examples and usage details for Background Repeat." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Background Repeat - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Background Repeat utility in Tailwind CSS. Examples and usage details for Background Repeat." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/backgrounds/background-repeat" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/backgrounds/background-size-page.tsx
+++ b/src/pages/backgrounds/background-size-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -87,6 +88,17 @@ const BackgroundSizePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Background Size - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Background Size utility in Tailwind CSS. Examples and usage details for Background Size." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Background Size - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Background Size utility in Tailwind CSS. Examples and usage details for Background Size." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/backgrounds/background-size" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/backgrounds/gradient-color-stops-page.tsx
+++ b/src/pages/backgrounds/gradient-color-stops-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -51,6 +52,17 @@ const GradientColorStopsPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Gradient Color Stops - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Gradient Color Stops utility in Tailwind CSS. Examples and usage details for Gradient Color Stops." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Gradient Color Stops - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Gradient Color Stops utility in Tailwind CSS. Examples and usage details for Gradient Color Stops." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/backgrounds/gradient-color-stops" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/border-color-page.tsx
+++ b/src/pages/borders/border-color-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -121,6 +122,17 @@ const BorderColorPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Border Color - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Border Color utility in Tailwind CSS. Examples and usage details for Border Color." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Border Color - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Border Color utility in Tailwind CSS. Examples and usage details for Border Color." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/border-color" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/border-radius-page.tsx
+++ b/src/pages/borders/border-radius-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -138,6 +139,17 @@ const BorderRadiusPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Border Radius - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Border Radius utility in Tailwind CSS. Examples and usage details for Border Radius." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Border Radius - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Border Radius utility in Tailwind CSS. Examples and usage details for Border Radius." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/border-radius" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/border-style-page.tsx
+++ b/src/pages/borders/border-style-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -56,6 +57,17 @@ const BorderStylePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Border Style - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Border Style utility in Tailwind CSS. Examples and usage details for Border Style." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Border Style - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Border Style utility in Tailwind CSS. Examples and usage details for Border Style." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/border-style" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/border-width-page.tsx
+++ b/src/pages/borders/border-width-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -84,6 +85,17 @@ const BorderWidthPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Border Width - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Border Width utility in Tailwind CSS. Examples and usage details for Border Width." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Border Width - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Border Width utility in Tailwind CSS. Examples and usage details for Border Width." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/border-width" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/divide-color-page.tsx
+++ b/src/pages/borders/divide-color-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -82,6 +83,17 @@ const DivideColorPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Divide Color - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Divide Color utility in Tailwind CSS. Examples and usage details for Divide Color." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Divide Color - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Divide Color utility in Tailwind CSS. Examples and usage details for Divide Color." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/divide-color" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/divide-style-page.tsx
+++ b/src/pages/borders/divide-style-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -86,6 +87,17 @@ const DivideStylePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Divide Style - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Divide Style utility in Tailwind CSS. Examples and usage details for Divide Style." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Divide Style - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Divide Style utility in Tailwind CSS. Examples and usage details for Divide Style." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/divide-style" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/divide-width-page.tsx
+++ b/src/pages/borders/divide-width-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -89,6 +90,17 @@ const DivideWidthPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Divide Width - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Divide Width utility in Tailwind CSS. Examples and usage details for Divide Width." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Divide Width - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Divide Width utility in Tailwind CSS. Examples and usage details for Divide Width." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/divide-width" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/outline-color-page.tsx
+++ b/src/pages/borders/outline-color-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -95,6 +96,17 @@ const OutlineColorPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Outline Color - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Outline Color utility in Tailwind CSS. Examples and usage details for Outline Color." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Outline Color - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Outline Color utility in Tailwind CSS. Examples and usage details for Outline Color." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/outline-color" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/outline-offset-page.tsx
+++ b/src/pages/borders/outline-offset-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -61,6 +62,17 @@ const OutlineOffsetPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Outline Offset - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Outline Offset utility in Tailwind CSS. Examples and usage details for Outline Offset." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Outline Offset - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Outline Offset utility in Tailwind CSS. Examples and usage details for Outline Offset." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/outline-offset" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/outline-style-page.tsx
+++ b/src/pages/borders/outline-style-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -67,6 +68,17 @@ const OutlineStylePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Outline Style - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Outline Style utility in Tailwind CSS. Examples and usage details for Outline Style." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Outline Style - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Outline Style utility in Tailwind CSS. Examples and usage details for Outline Style." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/outline-style" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/outline-width-page.tsx
+++ b/src/pages/borders/outline-width-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -51,6 +52,17 @@ const OutlineWidthPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Outline Width - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Outline Width utility in Tailwind CSS. Examples and usage details for Outline Width." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Outline Width - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Outline Width utility in Tailwind CSS. Examples and usage details for Outline Width." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/outline-width" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/ring-color-page.tsx
+++ b/src/pages/borders/ring-color-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -80,6 +81,17 @@ const RingColorPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Ring Color - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Ring Color utility in Tailwind CSS. Examples and usage details for Ring Color." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Ring Color - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Ring Color utility in Tailwind CSS. Examples and usage details for Ring Color." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/ring-color" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/ring-offset-color-page.tsx
+++ b/src/pages/borders/ring-offset-color-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -62,6 +63,17 @@ const RingOffsetColorPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Ring Offset Color - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Ring Offset Color utility in Tailwind CSS. Examples and usage details for Ring Offset Color." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Ring Offset Color - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Ring Offset Color utility in Tailwind CSS. Examples and usage details for Ring Offset Color." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/ring-offset-color" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/ring-offset-width-page.tsx
+++ b/src/pages/borders/ring-offset-width-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -65,6 +66,17 @@ const RingOffsetWidthPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Ring Offset Width - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Ring Offset Width utility in Tailwind CSS. Examples and usage details for Ring Offset Width." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Ring Offset Width - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Ring Offset Width utility in Tailwind CSS. Examples and usage details for Ring Offset Width." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/ring-offset-width" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/borders/ring-width-page.tsx
+++ b/src/pages/borders/ring-width-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -63,6 +64,17 @@ const RingWidthPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Ring Width - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Ring Width utility in Tailwind CSS. Examples and usage details for Ring Width." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Ring Width - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Ring Width utility in Tailwind CSS. Examples and usage details for Ring Width." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/borders/ring-width" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/effects/background-blend-mode-page.tsx
+++ b/src/pages/effects/background-blend-mode-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -45,6 +46,17 @@ const BackgroundBlendModePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Background Blend Mode - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Background Blend Mode utility in Tailwind CSS. Examples and usage details for Background Blend Mode." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Background Blend Mode - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Background Blend Mode utility in Tailwind CSS. Examples and usage details for Background Blend Mode." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/effects/background-blend-mode" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/effects/box-shadow-color-page.tsx
+++ b/src/pages/effects/box-shadow-color-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -65,6 +66,17 @@ const BoxShadowColorPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Box Shadow Color - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Box Shadow Color utility in Tailwind CSS. Examples and usage details for Box Shadow Color." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Box Shadow Color - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Box Shadow Color utility in Tailwind CSS. Examples and usage details for Box Shadow Color." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/effects/box-shadow-color" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/effects/box-shadow-page.tsx
+++ b/src/pages/effects/box-shadow-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -76,6 +77,17 @@ const BoxShadowPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Box Shadow - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Box Shadow utility in Tailwind CSS. Examples and usage details for Box Shadow." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Box Shadow - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Box Shadow utility in Tailwind CSS. Examples and usage details for Box Shadow." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/effects/box-shadow" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/effects/mix-blend-mode-page.tsx
+++ b/src/pages/effects/mix-blend-mode-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -49,6 +50,17 @@ const MixBlendModePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Mix Blend Mode - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Mix Blend Mode utility in Tailwind CSS. Examples and usage details for Mix Blend Mode." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Mix Blend Mode - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Mix Blend Mode utility in Tailwind CSS. Examples and usage details for Mix Blend Mode." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/effects/mix-blend-mode" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/effects/opacity-page.tsx
+++ b/src/pages/effects/opacity-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -60,6 +61,17 @@ const OpacityPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Opacity - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Opacity utility in Tailwind CSS. Examples and usage details for Opacity." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Opacity - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Opacity utility in Tailwind CSS. Examples and usage details for Opacity." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/effects/opacity" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/backdrop-blur-page.tsx
+++ b/src/pages/filters/backdrop-blur-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -109,6 +110,17 @@ const BackdropBlurPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Backdrop Blur - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Backdrop Blur utility in Tailwind CSS. Examples and usage details for Backdrop Blur." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Backdrop Blur - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Backdrop Blur utility in Tailwind CSS. Examples and usage details for Backdrop Blur." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/backdrop-blur" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/backdrop-brightness-page.tsx
+++ b/src/pages/filters/backdrop-brightness-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -105,6 +106,17 @@ const BackdropBrightnessPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Backdrop Brightness - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Backdrop Brightness utility in Tailwind CSS. Examples and usage details for Backdrop Brightness." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Backdrop Brightness - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Backdrop Brightness utility in Tailwind CSS. Examples and usage details for Backdrop Brightness." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/backdrop-brightness" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/backdrop-contrast-page.tsx
+++ b/src/pages/filters/backdrop-contrast-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -103,6 +104,17 @@ const BackdropContrastPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Backdrop Contrast - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Backdrop Contrast utility in Tailwind CSS. Examples and usage details for Backdrop Contrast." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Backdrop Contrast - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Backdrop Contrast utility in Tailwind CSS. Examples and usage details for Backdrop Contrast." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/backdrop-contrast" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/backdrop-grayscale-page.tsx
+++ b/src/pages/filters/backdrop-grayscale-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -79,6 +80,17 @@ const BackdropGrayscalePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Backdrop Grayscale - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Backdrop Grayscale utility in Tailwind CSS. Examples and usage details for Backdrop Grayscale." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Backdrop Grayscale - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Backdrop Grayscale utility in Tailwind CSS. Examples and usage details for Backdrop Grayscale." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/backdrop-grayscale" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/backdrop-hue-rotate-page.tsx
+++ b/src/pages/filters/backdrop-hue-rotate-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -102,6 +103,17 @@ const BackdropHueRotatePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Backdrop Hue Rotate - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Backdrop Hue Rotate utility in Tailwind CSS. Examples and usage details for Backdrop Hue Rotate." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Backdrop Hue Rotate - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Backdrop Hue Rotate utility in Tailwind CSS. Examples and usage details for Backdrop Hue Rotate." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/backdrop-hue-rotate" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/backdrop-invert-page.tsx
+++ b/src/pages/filters/backdrop-invert-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -79,6 +80,17 @@ const BackdropInvertPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Backdrop Invert - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Backdrop Invert utility in Tailwind CSS. Examples and usage details for Backdrop Invert." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Backdrop Invert - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Backdrop Invert utility in Tailwind CSS. Examples and usage details for Backdrop Invert." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/backdrop-invert" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/backdrop-opacity-page.tsx
+++ b/src/pages/filters/backdrop-opacity-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -99,6 +100,17 @@ const BackdropOpacityPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Backdrop Opacity - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Backdrop Opacity utility in Tailwind CSS. Examples and usage details for Backdrop Opacity." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Backdrop Opacity - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Backdrop Opacity utility in Tailwind CSS. Examples and usage details for Backdrop Opacity." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/backdrop-opacity" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/backdrop-saturate-page.tsx
+++ b/src/pages/filters/backdrop-saturate-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -94,6 +95,17 @@ const BackdropSaturatePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Backdrop Saturate - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Backdrop Saturate utility in Tailwind CSS. Examples and usage details for Backdrop Saturate." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Backdrop Saturate - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Backdrop Saturate utility in Tailwind CSS. Examples and usage details for Backdrop Saturate." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/backdrop-saturate" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/backdrop-sepia-page.tsx
+++ b/src/pages/filters/backdrop-sepia-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -79,6 +80,17 @@ const BackdropSepiaPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Backdrop Sepia - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Backdrop Sepia utility in Tailwind CSS. Examples and usage details for Backdrop Sepia." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Backdrop Sepia - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Backdrop Sepia utility in Tailwind CSS. Examples and usage details for Backdrop Sepia." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/backdrop-sepia" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/blur-page.tsx
+++ b/src/pages/filters/blur-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -57,6 +58,17 @@ const BlurPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Blur - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Blur utility in Tailwind CSS. Examples and usage details for Blur." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Blur - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Blur utility in Tailwind CSS. Examples and usage details for Blur." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/blur" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/brightness-page.tsx
+++ b/src/pages/filters/brightness-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -56,6 +57,17 @@ const BrightnessPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Brightness - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Brightness utility in Tailwind CSS. Examples and usage details for Brightness." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Brightness - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Brightness utility in Tailwind CSS. Examples and usage details for Brightness." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/brightness" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/contrast-page.tsx
+++ b/src/pages/filters/contrast-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -53,6 +54,17 @@ const ContrastPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Contrast - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Contrast utility in Tailwind CSS. Examples and usage details for Contrast." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Contrast - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Contrast utility in Tailwind CSS. Examples and usage details for Contrast." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/contrast" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/drop-shadow-page.tsx
+++ b/src/pages/filters/drop-shadow-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -92,6 +93,17 @@ const DropShadowPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Drop Shadow - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Drop Shadow utility in Tailwind CSS. Examples and usage details for Drop Shadow." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Drop Shadow - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Drop Shadow utility in Tailwind CSS. Examples and usage details for Drop Shadow." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/drop-shadow" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/grayscale-page.tsx
+++ b/src/pages/filters/grayscale-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -55,6 +56,17 @@ const GrayscalePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Grayscale - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Grayscale utility in Tailwind CSS. Examples and usage details for Grayscale." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Grayscale - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Grayscale utility in Tailwind CSS. Examples and usage details for Grayscale." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/grayscale" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/hue-rotate-page.tsx
+++ b/src/pages/filters/hue-rotate-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -55,6 +56,17 @@ const HueRotatePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Hue Rotate - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Hue Rotate utility in Tailwind CSS. Examples and usage details for Hue Rotate." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Hue Rotate - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Hue Rotate utility in Tailwind CSS. Examples and usage details for Hue Rotate." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/hue-rotate" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/invert-page.tsx
+++ b/src/pages/filters/invert-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -53,6 +54,17 @@ const InvertPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Invert - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Invert utility in Tailwind CSS. Examples and usage details for Invert." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Invert - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Invert utility in Tailwind CSS. Examples and usage details for Invert." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/invert" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/saturate-page.tsx
+++ b/src/pages/filters/saturate-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -51,6 +52,17 @@ const SaturatePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Saturate - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Saturate utility in Tailwind CSS. Examples and usage details for Saturate." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Saturate - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Saturate utility in Tailwind CSS. Examples and usage details for Saturate." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/saturate" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/filters/sepia-page.tsx
+++ b/src/pages/filters/sepia-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -49,6 +50,17 @@ const SepiaPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Sepia - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Sepia utility in Tailwind CSS. Examples and usage details for Sepia." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Sepia - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Sepia utility in Tailwind CSS. Examples and usage details for Sepia." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/filters/sepia" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/align-content-page.tsx
+++ b/src/pages/flexbox-grid/align-content-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -195,6 +196,17 @@ const AlignContentPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Align Content - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Align Content utility in Tailwind CSS. Examples and usage details for Align Content." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Align Content - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Align Content utility in Tailwind CSS. Examples and usage details for Align Content." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/align-content" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/align-items-page.tsx
+++ b/src/pages/flexbox-grid/align-items-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -88,6 +89,17 @@ const AlignItemsPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Align Items - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Align Items utility in Tailwind CSS. Examples and usage details for Align Items." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Align Items - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Align Items utility in Tailwind CSS. Examples and usage details for Align Items." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/align-items" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/align-self-page.tsx
+++ b/src/pages/flexbox-grid/align-self-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -51,6 +52,17 @@ const AlignSelfPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Align Self - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Align Self utility in Tailwind CSS. Examples and usage details for Align Self." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Align Self - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Align Self utility in Tailwind CSS. Examples and usage details for Align Self." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/align-self" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/flex-basis-page.tsx
+++ b/src/pages/flexbox-grid/flex-basis-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -108,6 +109,17 @@ const FlexBasisPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Flex Basis - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Flex Basis utility in Tailwind CSS. Examples and usage details for Flex Basis." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Flex Basis - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Flex Basis utility in Tailwind CSS. Examples and usage details for Flex Basis." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/flex-basis" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/flex-direction-page.tsx
+++ b/src/pages/flexbox-grid/flex-direction-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -99,6 +100,17 @@ const FlexDirectionPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Flex Direction - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Flex Direction utility in Tailwind CSS. Examples and usage details for Flex Direction." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Flex Direction - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Flex Direction utility in Tailwind CSS. Examples and usage details for Flex Direction." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/flex-direction" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/flex-grow-page.tsx
+++ b/src/pages/flexbox-grid/flex-grow-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -96,6 +97,17 @@ const FlexGrowPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Flex Grow - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Flex Grow utility in Tailwind CSS. Examples and usage details for Flex Grow." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Flex Grow - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Flex Grow utility in Tailwind CSS. Examples and usage details for Flex Grow." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/flex-grow" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/flex-page.tsx
+++ b/src/pages/flexbox-grid/flex-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -120,6 +121,17 @@ const FlexPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Flex - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Flex utility in Tailwind CSS. Examples and usage details for Flex." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Flex - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Flex utility in Tailwind CSS. Examples and usage details for Flex." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/flex" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/flex-shrink-page.tsx
+++ b/src/pages/flexbox-grid/flex-shrink-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -105,6 +106,17 @@ const FlexShrinkPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Flex Shrink - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Flex Shrink utility in Tailwind CSS. Examples and usage details for Flex Shrink." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Flex Shrink - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Flex Shrink utility in Tailwind CSS. Examples and usage details for Flex Shrink." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/flex-shrink" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/flex-wrap-page.tsx
+++ b/src/pages/flexbox-grid/flex-wrap-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -112,6 +113,17 @@ const FlexWrapPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Flex Wrap - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Flex Wrap utility in Tailwind CSS. Examples and usage details for Flex Wrap." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Flex Wrap - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Flex Wrap utility in Tailwind CSS. Examples and usage details for Flex Wrap." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/flex-wrap" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/gap-page.tsx
+++ b/src/pages/flexbox-grid/gap-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -113,6 +114,17 @@ const GapPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Gap - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Gap utility in Tailwind CSS. Examples and usage details for Gap." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Gap - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Gap utility in Tailwind CSS. Examples and usage details for Gap." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/gap" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/grid-auto-columns-page.tsx
+++ b/src/pages/flexbox-grid/grid-auto-columns-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -104,6 +105,17 @@ const GridAutoColumnsPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Grid Auto Columns - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Grid Auto Columns utility in Tailwind CSS. Examples and usage details for Grid Auto Columns." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Grid Auto Columns - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Grid Auto Columns utility in Tailwind CSS. Examples and usage details for Grid Auto Columns." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/grid-auto-columns" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/grid-auto-flow-page.tsx
+++ b/src/pages/flexbox-grid/grid-auto-flow-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -122,6 +123,17 @@ const GridAutoFlowPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Grid Auto Flow - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Grid Auto Flow utility in Tailwind CSS. Examples and usage details for Grid Auto Flow." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Grid Auto Flow - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Grid Auto Flow utility in Tailwind CSS. Examples and usage details for Grid Auto Flow." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/grid-auto-flow" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/grid-auto-rows-page.tsx
+++ b/src/pages/flexbox-grid/grid-auto-rows-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -98,6 +99,17 @@ const GridAutoRowsPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Grid Auto Rows - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Grid Auto Rows utility in Tailwind CSS. Examples and usage details for Grid Auto Rows." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Grid Auto Rows - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Grid Auto Rows utility in Tailwind CSS. Examples and usage details for Grid Auto Rows." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/grid-auto-rows" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/grid-column-page.tsx
+++ b/src/pages/flexbox-grid/grid-column-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -110,6 +111,17 @@ const GridColumnPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Grid Column - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Grid Column utility in Tailwind CSS. Examples and usage details for Grid Column." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Grid Column - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Grid Column utility in Tailwind CSS. Examples and usage details for Grid Column." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/grid-column" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/grid-row-page.tsx
+++ b/src/pages/flexbox-grid/grid-row-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -122,6 +123,17 @@ const GridRowPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Grid Row - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Grid Row utility in Tailwind CSS. Examples and usage details for Grid Row." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Grid Row - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Grid Row utility in Tailwind CSS. Examples and usage details for Grid Row." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/grid-row" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/grid-template-columns-page.tsx
+++ b/src/pages/flexbox-grid/grid-template-columns-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -115,6 +116,17 @@ const GridTemplateColumnsPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Grid Template Columns - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Grid Template Columns utility in Tailwind CSS. Examples and usage details for Grid Template Columns." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Grid Template Columns - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Grid Template Columns utility in Tailwind CSS. Examples and usage details for Grid Template Columns." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/grid-template-columns" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/grid-template-rows-page.tsx
+++ b/src/pages/flexbox-grid/grid-template-rows-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -119,6 +120,17 @@ const GridTemplateRowsPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Grid Template Rows - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Grid Template Rows utility in Tailwind CSS. Examples and usage details for Grid Template Rows." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Grid Template Rows - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Grid Template Rows utility in Tailwind CSS. Examples and usage details for Grid Template Rows." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/grid-template-rows" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/flexbox-grid/justify-content-page.tsx
+++ b/src/pages/flexbox-grid/justify-content-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -116,6 +117,17 @@ const JustifyContentPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Justify Content - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Justify Content utility in Tailwind CSS. Examples and usage details for Justify Content." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Justify Content - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Justify Content utility in Tailwind CSS. Examples and usage details for Justify Content." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/justify-content" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/justify-items-page.tsx
+++ b/src/pages/flexbox-grid/justify-items-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -80,6 +81,17 @@ const JustifyItemsPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Justify Items - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Justify Items utility in Tailwind CSS. Examples and usage details for Justify Items." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Justify Items - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Justify Items utility in Tailwind CSS. Examples and usage details for Justify Items." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/justify-items" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/justify-self-page.tsx
+++ b/src/pages/flexbox-grid/justify-self-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -47,6 +48,17 @@ const JustifySelfPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Justify Self - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Justify Self utility in Tailwind CSS. Examples and usage details for Justify Self." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Justify Self - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Justify Self utility in Tailwind CSS. Examples and usage details for Justify Self." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/justify-self" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/order-page.tsx
+++ b/src/pages/flexbox-grid/order-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -99,6 +100,17 @@ const OrderPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Order - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Order utility in Tailwind CSS. Examples and usage details for Order." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Order - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Order utility in Tailwind CSS. Examples and usage details for Order." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/order" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/place-content-page.tsx
+++ b/src/pages/flexbox-grid/place-content-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -118,6 +119,17 @@ const PlaceContentPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Place Content - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Place Content utility in Tailwind CSS. Examples and usage details for Place Content." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Place Content - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Place Content utility in Tailwind CSS. Examples and usage details for Place Content." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/place-content" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/place-items-page.tsx
+++ b/src/pages/flexbox-grid/place-items-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -77,6 +78,17 @@ const PlaceItemsPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Place Items - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Place Items utility in Tailwind CSS. Examples and usage details for Place Items." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Place Items - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Place Items utility in Tailwind CSS. Examples and usage details for Place Items." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/place-items" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/flexbox-grid/place-self-page.tsx
+++ b/src/pages/flexbox-grid/place-self-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -50,6 +51,17 @@ const PlaceSelfPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Place Self - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Place Self utility in Tailwind CSS. Examples and usage details for Place Self." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Place Self - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Place Self utility in Tailwind CSS. Examples and usage details for Place Self." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/flexbox-grid/place-self" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/accent-color-page.tsx
+++ b/src/pages/interactivity/accent-color-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -83,6 +84,17 @@ const AccentColorPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Accent Color - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Accent Color utility in Tailwind CSS. Examples and usage details for Accent Color." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Accent Color - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Accent Color utility in Tailwind CSS. Examples and usage details for Accent Color." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/accent-color" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/appearance-page.tsx
+++ b/src/pages/interactivity/appearance-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -95,6 +96,17 @@ const AppearancePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Appearance - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Appearance utility in Tailwind CSS. Examples and usage details for Appearance." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Appearance - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Appearance utility in Tailwind CSS. Examples and usage details for Appearance." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/appearance" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/caret-color-page.tsx
+++ b/src/pages/interactivity/caret-color-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -120,6 +121,17 @@ const CaretColorPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Caret Color - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Caret Color utility in Tailwind CSS. Examples and usage details for Caret Color." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Caret Color - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Caret Color utility in Tailwind CSS. Examples and usage details for Caret Color." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/caret-color" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/cursor-page.tsx
+++ b/src/pages/interactivity/cursor-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -143,6 +144,17 @@ const CursorPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Cursor - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Cursor utility in Tailwind CSS. Examples and usage details for Cursor." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Cursor - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Cursor utility in Tailwind CSS. Examples and usage details for Cursor." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/cursor" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/pointer-events-page.tsx
+++ b/src/pages/interactivity/pointer-events-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -51,6 +52,17 @@ const PointerEventsPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Pointer Events - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Pointer Events utility in Tailwind CSS. Examples and usage details for Pointer Events." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Pointer Events - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Pointer Events utility in Tailwind CSS. Examples and usage details for Pointer Events." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/pointer-events" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/resize-page.tsx
+++ b/src/pages/interactivity/resize-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -94,6 +95,17 @@ const ResizePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Resize - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Resize utility in Tailwind CSS. Examples and usage details for Resize." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Resize - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Resize utility in Tailwind CSS. Examples and usage details for Resize." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/resize" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/scroll-behavior-page.tsx
+++ b/src/pages/interactivity/scroll-behavior-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React, { useRef } from 'react';
 
@@ -111,6 +112,17 @@ const ScrollBehaviorPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Scroll Behavior - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Scroll Behavior utility in Tailwind CSS. Examples and usage details for Scroll Behavior." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Scroll Behavior - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Scroll Behavior utility in Tailwind CSS. Examples and usage details for Scroll Behavior." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/scroll-behavior" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/scroll-margin-page.tsx
+++ b/src/pages/interactivity/scroll-margin-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React, { useRef } from 'react';
 
@@ -160,6 +161,17 @@ const ScrollMarginPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Scroll Margin - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Scroll Margin utility in Tailwind CSS. Examples and usage details for Scroll Margin." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Scroll Margin - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Scroll Margin utility in Tailwind CSS. Examples and usage details for Scroll Margin." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/scroll-margin" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/scroll-padding-page.tsx
+++ b/src/pages/interactivity/scroll-padding-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React, { useRef } from 'react';
 
@@ -163,6 +164,17 @@ const ScrollPaddingPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Scroll Padding - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Scroll Padding utility in Tailwind CSS. Examples and usage details for Scroll Padding." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Scroll Padding - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Scroll Padding utility in Tailwind CSS. Examples and usage details for Scroll Padding." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/scroll-padding" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/scroll-snap-align-page.tsx
+++ b/src/pages/interactivity/scroll-snap-align-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -121,6 +122,17 @@ const ScrollSnapAlignPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Scroll Snap Align - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Scroll Snap Align utility in Tailwind CSS. Examples and usage details for Scroll Snap Align." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Scroll Snap Align - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Scroll Snap Align utility in Tailwind CSS. Examples and usage details for Scroll Snap Align." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/scroll-snap-align" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/scroll-snap-stop-page.tsx
+++ b/src/pages/interactivity/scroll-snap-stop-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -87,6 +88,17 @@ const ScrollSnapStopPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Scroll Snap Stop - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Scroll Snap Stop utility in Tailwind CSS. Examples and usage details for Scroll Snap Stop." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Scroll Snap Stop - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Scroll Snap Stop utility in Tailwind CSS. Examples and usage details for Scroll Snap Stop." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/scroll-snap-stop" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/scroll-snap-type-page.tsx
+++ b/src/pages/interactivity/scroll-snap-type-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -161,6 +162,17 @@ const ScrollSnapTypePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Scroll Snap Type - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Scroll Snap Type utility in Tailwind CSS. Examples and usage details for Scroll Snap Type." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Scroll Snap Type - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Scroll Snap Type utility in Tailwind CSS. Examples and usage details for Scroll Snap Type." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/scroll-snap-type" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/touch-action-page.tsx
+++ b/src/pages/interactivity/touch-action-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -127,6 +128,17 @@ const TouchActionPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Touch Action - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Touch Action utility in Tailwind CSS. Examples and usage details for Touch Action." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Touch Action - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Touch Action utility in Tailwind CSS. Examples and usage details for Touch Action." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/touch-action" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/user-select-page.tsx
+++ b/src/pages/interactivity/user-select-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -68,6 +69,17 @@ const UserSelectPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>User Select - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the User Select utility in Tailwind CSS. Examples and usage details for User Select." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="User Select - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the User Select utility in Tailwind CSS. Examples and usage details for User Select." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/user-select" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/interactivity/will-change-page.tsx
+++ b/src/pages/interactivity/will-change-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -87,6 +88,17 @@ const WillChangePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Will Change - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Will Change utility in Tailwind CSS. Examples and usage details for Will Change." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Will Change - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Will Change utility in Tailwind CSS. Examples and usage details for Will Change." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/interactivity/will-change" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/layout/aspect-ratio-page.tsx
+++ b/src/pages/layout/aspect-ratio-page.tsx
@@ -1,4 +1,5 @@
 import ArticleLayout from '@/components/layout/ArticleLayout';
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'; // Card コンポーネントをインポート
 import React from 'react';
 
@@ -143,6 +144,16 @@ module.exports = {
 
   return (
     <ArticleLayout title="Layout: Aspect Ratio (アスペクト比)" links={links}>
+      <Helmet>
+        <title>Aspect Ratio - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn how to control the aspect ratio of elements using Tailwind CSS utility classes like aspect-square, aspect-video, and custom ratios." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Aspect Ratio - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn how to control the aspect ratio of elements using Tailwind CSS utility classes like aspect-square, aspect-video, and custom ratios." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/aspect-ratio" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       {/* 概要 Card */}
       <Card>
         <CardHeader>

--- a/src/pages/layout/box-decoration-break-page.tsx
+++ b/src/pages/layout/box-decoration-break-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -78,6 +79,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Box Decoration Break (要素分割時の装飾)" links={links}>
+
+      <Helmet>
+        <title>Layout: Box Decoration Break - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Box Decoration Break utility in Tailwind CSS. Examples and usage details for Layout: Box Decoration Break." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Box Decoration Break - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Box Decoration Break utility in Tailwind CSS. Examples and usage details for Layout: Box Decoration Break." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/box-decoration-break" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/box-sizing-page.tsx
+++ b/src/pages/layout/box-sizing-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -73,6 +74,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Box Sizing (ボックスサイジング)" links={links}>
+
+      <Helmet>
+        <title>Layout: Box Sizing - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Box Sizing utility in Tailwind CSS. Examples and usage details for Layout: Box Sizing." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Box Sizing - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Box Sizing utility in Tailwind CSS. Examples and usage details for Layout: Box Sizing." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/box-sizing" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/break-after-page.tsx
+++ b/src/pages/layout/break-after-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -138,6 +139,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Break After (要素後の改ページ/改カラム)" links={links}>
+
+      <Helmet>
+        <title>Layout: Break After - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Break After utility in Tailwind CSS. Examples and usage details for Layout: Break After." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Break After - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Break After utility in Tailwind CSS. Examples and usage details for Layout: Break After." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/break-after" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/break-before-page.tsx
+++ b/src/pages/layout/break-before-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -138,6 +139,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Break Before (要素前の改ページ/改カラム)" links={links}>
+
+      <Helmet>
+        <title>Layout: Break Before - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Break Before utility in Tailwind CSS. Examples and usage details for Layout: Break Before." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Break Before - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Break Before utility in Tailwind CSS. Examples and usage details for Layout: Break Before." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/break-before" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/break-inside-page.tsx
+++ b/src/pages/layout/break-inside-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -152,6 +153,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Break Inside (要素内の改ページ/改カラム回避)" links={links}>
+
+      <Helmet>
+        <title>Layout: Break Inside - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Break Inside utility in Tailwind CSS. Examples and usage details for Layout: Break Inside." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Break Inside - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Break Inside utility in Tailwind CSS. Examples and usage details for Layout: Break Inside." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/break-inside" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/clear-page.tsx
+++ b/src/pages/layout/clear-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -144,6 +145,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Clear (回り込み解除)" links={links}>
+
+      <Helmet>
+        <title>Layout: Clear - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Clear utility in Tailwind CSS. Examples and usage details for Layout: Clear." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Clear - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Clear utility in Tailwind CSS. Examples and usage details for Layout: Clear." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/clear" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/columns-page.tsx
+++ b/src/pages/layout/columns-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -111,6 +112,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Columns (カラム)" links={links}>
+
+      <Helmet>
+        <title>Layout: Columns - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Columns utility in Tailwind CSS. Examples and usage details for Layout: Columns." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Columns - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Columns utility in Tailwind CSS. Examples and usage details for Layout: Columns." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/columns" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/container-page.tsx
+++ b/src/pages/layout/container-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -91,6 +92,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Container (コンテナ)" links={links}>
+
+      <Helmet>
+        <title>Layout: Container - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Container utility in Tailwind CSS. Examples and usage details for Layout: Container." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Container - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Container utility in Tailwind CSS. Examples and usage details for Layout: Container." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/container" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/display-page.tsx
+++ b/src/pages/layout/display-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import React from 'react';
@@ -159,6 +160,17 @@ const DisplayPage: React.FC = () => {
 
   return (
     <ArticleLayout title="Layout: Display (表示タイプ)" links={links}>
+
+      <Helmet>
+        <title>Layout: Display - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Display utility in Tailwind CSS. Examples and usage details for Layout: Display." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Display - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Display utility in Tailwind CSS. Examples and usage details for Layout: Display." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/display" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       {/* 概要 Card */}
       <Card>
         <CardHeader>

--- a/src/pages/layout/floats-page.tsx
+++ b/src/pages/layout/floats-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -101,6 +102,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Floats (フロート)" links={links}>
+
+      <Helmet>
+        <title>Layout: Floats - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Floats utility in Tailwind CSS. Examples and usage details for Layout: Floats." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Floats - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Floats utility in Tailwind CSS. Examples and usage details for Layout: Floats." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/floats" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/isolation-page.tsx
+++ b/src/pages/layout/isolation-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -123,6 +124,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Isolation (分離)" links={links}>
+
+      <Helmet>
+        <title>Layout: Isolation - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Isolation utility in Tailwind CSS. Examples and usage details for Layout: Isolation." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Isolation - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Isolation utility in Tailwind CSS. Examples and usage details for Layout: Isolation." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/isolation" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/object-fit-page.tsx
+++ b/src/pages/layout/object-fit-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import React from 'react';
@@ -127,6 +128,17 @@ const ObjectFitPage: React.FC = () => {
 
   return (
     <ArticleLayout title="Layout: Object Fit (置換要素のフィット方法)" links={links}>
+
+      <Helmet>
+        <title>Layout: Object Fit - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Object Fit utility in Tailwind CSS. Examples and usage details for Layout: Object Fit." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Object Fit - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Object Fit utility in Tailwind CSS. Examples and usage details for Layout: Object Fit." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/object-fit" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       {/* 概要 Card */}
       <Card>
         <CardHeader>

--- a/src/pages/layout/object-position-page.tsx
+++ b/src/pages/layout/object-position-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -126,6 +127,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Object Position (置換要素の位置)" links={links}>
+
+      <Helmet>
+        <title>Layout: Object Position - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Object Position utility in Tailwind CSS. Examples and usage details for Layout: Object Position." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Object Position - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Object Position utility in Tailwind CSS. Examples and usage details for Layout: Object Position." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/object-position" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/overflow-page.tsx
+++ b/src/pages/layout/overflow-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -126,6 +127,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Overflow (オーバーフロー)" links={links}>
+
+      <Helmet>
+        <title>Layout: Overflow - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Overflow utility in Tailwind CSS. Examples and usage details for Layout: Overflow." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Overflow - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Overflow utility in Tailwind CSS. Examples and usage details for Layout: Overflow." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/overflow" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/overscroll-behavior-page.tsx
+++ b/src/pages/layout/overscroll-behavior-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import React from 'react';
@@ -136,6 +137,17 @@ const OverscrollBehaviorPage: React.FC = () => {
 
   return (
     <ArticleLayout title="Layout: Overscroll Behavior (オーバースクロール挙動)" links={links}>
+
+      <Helmet>
+        <title>Layout: Overscroll Behavior - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Overscroll Behavior utility in Tailwind CSS. Examples and usage details for Layout: Overscroll Behavior." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Overscroll Behavior - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Overscroll Behavior utility in Tailwind CSS. Examples and usage details for Layout: Overscroll Behavior." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/overscroll-behavior" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       {/* 概要 Card */}
       <Card>
         <CardHeader>

--- a/src/pages/layout/position-page.tsx
+++ b/src/pages/layout/position-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -111,6 +112,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Position (配置)" links={links}>
+
+      <Helmet>
+        <title>Layout: Position - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Position utility in Tailwind CSS. Examples and usage details for Layout: Position." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Position - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Position utility in Tailwind CSS. Examples and usage details for Layout: Position." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/position" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/top-right-bottom-left-page.tsx
+++ b/src/pages/layout/top-right-bottom-left-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -143,6 +144,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Top / Right / Bottom / Left (配置オフセット)" links={links}>
+
+      <Helmet>
+        <title>Layout: Top / Right / Bottom / Left - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Top / Right / Bottom / Left utility in Tailwind CSS. Examples and usage details for Layout: Top / Right / Bottom / Left." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Top / Right / Bottom / Left - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Top / Right / Bottom / Left utility in Tailwind CSS. Examples and usage details for Layout: Top / Right / Bottom / Left." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/top-right-bottom-left" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/visibility-page.tsx
+++ b/src/pages/layout/visibility-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -64,6 +65,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Visibility (可視性)" links={links}>
+
+      <Helmet>
+        <title>Layout: Visibility - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Visibility utility in Tailwind CSS. Examples and usage details for Layout: Visibility." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Visibility - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Visibility utility in Tailwind CSS. Examples and usage details for Layout: Visibility." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/visibility" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/layout/z-index-page.tsx
+++ b/src/pages/layout/z-index-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import ArticleLayout from '@/components/layout/ArticleLayout'; // ArticleLayout をインポート
@@ -99,6 +100,17 @@ const links = [
 
   return (
     <ArticleLayout title="Layout: Z-Index (重ね順)" links={links}>
+
+      <Helmet>
+        <title>Layout: Z-Index - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Layout: Z-Index utility in Tailwind CSS. Examples and usage details for Layout: Z-Index." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Layout: Z-Index - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Layout: Z-Index utility in Tailwind CSS. Examples and usage details for Layout: Z-Index." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/layout/z-index" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
         {/* 概要 Card */}
         <Card>
           <CardHeader>

--- a/src/pages/sizing/height-page.tsx
+++ b/src/pages/sizing/height-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -121,6 +122,17 @@ const HeightPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Height - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Height utility in Tailwind CSS. Examples and usage details for Height." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Height - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Height utility in Tailwind CSS. Examples and usage details for Height." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/sizing/height" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/sizing/max-height-page.tsx
+++ b/src/pages/sizing/max-height-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -144,6 +145,17 @@ const MaxHeightPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Max Height - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Max Height utility in Tailwind CSS. Examples and usage details for Max Height." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Max Height - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Max Height utility in Tailwind CSS. Examples and usage details for Max Height." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/sizing/max-height" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/sizing/max-width-page.tsx
+++ b/src/pages/sizing/max-width-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -95,6 +96,17 @@ const MaxWidthPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Max Width - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Max Width utility in Tailwind CSS. Examples and usage details for Max Width." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Max Width - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Max Width utility in Tailwind CSS. Examples and usage details for Max Width." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/sizing/max-width" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/sizing/min-height-page.tsx
+++ b/src/pages/sizing/min-height-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -96,6 +97,17 @@ const MinHeightPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Min Height - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Min Height utility in Tailwind CSS. Examples and usage details for Min Height." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Min Height - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Min Height utility in Tailwind CSS. Examples and usage details for Min Height." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/sizing/min-height" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/sizing/min-width-page.tsx
+++ b/src/pages/sizing/min-width-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -84,6 +85,17 @@ const MinWidthPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Min Width - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Min Width utility in Tailwind CSS. Examples and usage details for Min Width." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Min Width - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Min Width utility in Tailwind CSS. Examples and usage details for Min Width." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/sizing/min-width" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/sizing/size-page.tsx
+++ b/src/pages/sizing/size-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -109,6 +110,17 @@ const SizePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Size - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Size utility in Tailwind CSS. Examples and usage details for Size." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Size - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Size utility in Tailwind CSS. Examples and usage details for Size." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/sizing/size" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/sizing/width-page.tsx
+++ b/src/pages/sizing/width-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -111,6 +112,17 @@ const WidthPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Width - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Width utility in Tailwind CSS. Examples and usage details for Width." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Width - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Width utility in Tailwind CSS. Examples and usage details for Width." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/sizing/width" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/spacing/margin-page.tsx
+++ b/src/pages/spacing/margin-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -125,6 +126,17 @@ const MarginPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Margin - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Margin utility in Tailwind CSS. Examples and usage details for Margin." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Margin - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Margin utility in Tailwind CSS. Examples and usage details for Margin." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/spacing/margin" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/spacing/padding-page.tsx
+++ b/src/pages/spacing/padding-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -73,6 +74,17 @@ const PaddingPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Padding - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Padding utility in Tailwind CSS. Examples and usage details for Padding." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Padding - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Padding utility in Tailwind CSS. Examples and usage details for Padding." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/spacing/padding" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/spacing/space-between-page.tsx
+++ b/src/pages/spacing/space-between-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -97,6 +98,17 @@ const SpaceBetweenPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Space Between - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Space Between utility in Tailwind CSS. Examples and usage details for Space Between." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Space Between - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Space Between utility in Tailwind CSS. Examples and usage details for Space Between." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/spacing/space-between" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/svg/fill-page.tsx
+++ b/src/pages/svg/fill-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -67,6 +68,17 @@ const FillPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Fill - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Fill utility in Tailwind CSS. Examples and usage details for Fill." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Fill - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Fill utility in Tailwind CSS. Examples and usage details for Fill." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/svg/fill" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/svg/stroke-page.tsx
+++ b/src/pages/svg/stroke-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -67,6 +68,17 @@ const StrokePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Stroke - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Stroke utility in Tailwind CSS. Examples and usage details for Stroke." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Stroke - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Stroke utility in Tailwind CSS. Examples and usage details for Stroke." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/svg/stroke" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/svg/stroke-width-page.tsx
+++ b/src/pages/svg/stroke-width-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -61,6 +62,17 @@ const StrokeWidthPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Stroke Width - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Stroke Width utility in Tailwind CSS. Examples and usage details for Stroke Width." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Stroke Width - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Stroke Width utility in Tailwind CSS. Examples and usage details for Stroke Width." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/svg/stroke-width" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/tables/border-collapse-page.tsx
+++ b/src/pages/tables/border-collapse-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -119,6 +120,17 @@ const BorderCollapsePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Border Collapse - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Border Collapse utility in Tailwind CSS. Examples and usage details for Border Collapse." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Border Collapse - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Border Collapse utility in Tailwind CSS. Examples and usage details for Border Collapse." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/tables/border-collapse" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/tables/border-spacing-page.tsx
+++ b/src/pages/tables/border-spacing-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -107,6 +108,17 @@ const BorderSpacingPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Border Spacing - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Border Spacing utility in Tailwind CSS. Examples and usage details for Border Spacing." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Border Spacing - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Border Spacing utility in Tailwind CSS. Examples and usage details for Border Spacing." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/tables/border-spacing" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/tables/caption-side-page.tsx
+++ b/src/pages/tables/caption-side-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -94,6 +95,17 @@ const CaptionSidePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Caption Side - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Caption Side utility in Tailwind CSS. Examples and usage details for Caption Side." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Caption Side - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Caption Side utility in Tailwind CSS. Examples and usage details for Caption Side." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/tables/caption-side" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/tables/table-layout-page.tsx
+++ b/src/pages/tables/table-layout-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -117,6 +118,17 @@ const TableLayoutPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Table Layout - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Table Layout utility in Tailwind CSS. Examples and usage details for Table Layout." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Table Layout - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Table Layout utility in Tailwind CSS. Examples and usage details for Table Layout." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/tables/table-layout" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/transforms/rotate-page.tsx
+++ b/src/pages/transforms/rotate-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -87,6 +88,17 @@ const RotatePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Rotate - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Rotate utility in Tailwind CSS. Examples and usage details for Rotate." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Rotate - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Rotate utility in Tailwind CSS. Examples and usage details for Rotate." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/transforms/rotate" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/transforms/scale-page.tsx
+++ b/src/pages/transforms/scale-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -115,6 +116,17 @@ const ScalePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Scale - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Scale utility in Tailwind CSS. Examples and usage details for Scale." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Scale - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Scale utility in Tailwind CSS. Examples and usage details for Scale." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/transforms/scale" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/transforms/skew-page.tsx
+++ b/src/pages/transforms/skew-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -95,6 +96,17 @@ const SkewPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Skew - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Skew utility in Tailwind CSS. Examples and usage details for Skew." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Skew - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Skew utility in Tailwind CSS. Examples and usage details for Skew." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/transforms/skew" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/transforms/transform-origin-page.tsx
+++ b/src/pages/transforms/transform-origin-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -72,6 +73,17 @@ const TransformOriginPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Transform Origin - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Transform Origin utility in Tailwind CSS. Examples and usage details for Transform Origin." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Transform Origin - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Transform Origin utility in Tailwind CSS. Examples and usage details for Transform Origin." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/transforms/transform-origin" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/transforms/translate-page.tsx
+++ b/src/pages/transforms/translate-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -67,6 +68,17 @@ const TranslatePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Translate - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Translate utility in Tailwind CSS. Examples and usage details for Translate." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Translate - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Translate utility in Tailwind CSS. Examples and usage details for Translate." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/transforms/translate" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/transitions-animation/animation-page.tsx
+++ b/src/pages/transitions-animation/animation-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -106,6 +107,17 @@ const AnimationPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Animation - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Animation utility in Tailwind CSS. Examples and usage details for Animation." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Animation - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Animation utility in Tailwind CSS. Examples and usage details for Animation." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/transitions-animation/animation" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/transitions-animation/transition-delay-page.tsx
+++ b/src/pages/transitions-animation/transition-delay-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -66,6 +67,17 @@ const TransitionDelayPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Transition Delay - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Transition Delay utility in Tailwind CSS. Examples and usage details for Transition Delay." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Transition Delay - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Transition Delay utility in Tailwind CSS. Examples and usage details for Transition Delay." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/transitions-animation/transition-delay" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/transitions-animation/transition-duration-page.tsx
+++ b/src/pages/transitions-animation/transition-duration-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -66,6 +67,17 @@ const TransitionDurationPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Transition Duration - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Transition Duration utility in Tailwind CSS. Examples and usage details for Transition Duration." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Transition Duration - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Transition Duration utility in Tailwind CSS. Examples and usage details for Transition Duration." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/transitions-animation/transition-duration" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/transitions-animation/transition-property-page.tsx
+++ b/src/pages/transitions-animation/transition-property-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -81,6 +82,17 @@ const TransitionPropertyPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Transition Property - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Transition Property utility in Tailwind CSS. Examples and usage details for Transition Property." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Transition Property - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Transition Property utility in Tailwind CSS. Examples and usage details for Transition Property." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/transitions-animation/transition-property" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/transitions-animation/transition-timing-function-page.tsx
+++ b/src/pages/transitions-animation/transition-timing-function-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -76,6 +77,17 @@ const TransitionTimingFunctionPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Transition Timing Function - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Transition Timing Function utility in Tailwind CSS. Examples and usage details for Transition Timing Function." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Transition Timing Function - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Transition Timing Function utility in Tailwind CSS. Examples and usage details for Transition Timing Function." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/transitions-animation/transition-timing-function" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/content-page.tsx
+++ b/src/pages/typography/content-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -87,6 +88,17 @@ const ContentPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Content - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Content utility in Tailwind CSS. Examples and usage details for Content." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Content - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Content utility in Tailwind CSS. Examples and usage details for Content." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/content" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/font-family-page.tsx
+++ b/src/pages/typography/font-family-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -51,6 +52,17 @@ module.exports = {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Font Family - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Font Family utility in Tailwind CSS. Examples and usage details for Font Family." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Font Family - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Font Family utility in Tailwind CSS. Examples and usage details for Font Family." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/font-family" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/typography/font-size-page.tsx
+++ b/src/pages/typography/font-size-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -55,6 +56,17 @@ const FontSizePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Font Size - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Font Size utility in Tailwind CSS. Examples and usage details for Font Size." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Font Size - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Font Size utility in Tailwind CSS. Examples and usage details for Font Size." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/font-size" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/typography/font-smoothing-page.tsx
+++ b/src/pages/typography/font-smoothing-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -50,6 +51,17 @@ const FontSmoothingPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Font Smoothing - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Font Smoothing utility in Tailwind CSS. Examples and usage details for Font Smoothing." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Font Smoothing - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Font Smoothing utility in Tailwind CSS. Examples and usage details for Font Smoothing." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/font-smoothing" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/font-style-page.tsx
+++ b/src/pages/typography/font-style-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -42,6 +43,17 @@ const FontStylePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Font Style - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Font Style utility in Tailwind CSS. Examples and usage details for Font Style." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Font Style - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Font Style utility in Tailwind CSS. Examples and usage details for Font Style." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/font-style" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/font-variant-numeric-page.tsx
+++ b/src/pages/typography/font-variant-numeric-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -65,6 +66,17 @@ const FontVariantNumericPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Font Variant Numeric - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Font Variant Numeric utility in Tailwind CSS. Examples and usage details for Font Variant Numeric." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Font Variant Numeric - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Font Variant Numeric utility in Tailwind CSS. Examples and usage details for Font Variant Numeric." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/font-variant-numeric" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/font-weight-page.tsx
+++ b/src/pages/typography/font-weight-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -49,6 +50,17 @@ const FontWeightPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Font Weight - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Font Weight utility in Tailwind CSS. Examples and usage details for Font Weight." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Font Weight - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Font Weight utility in Tailwind CSS. Examples and usage details for Font Weight." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/font-weight" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/hyphens-page.tsx
+++ b/src/pages/typography/hyphens-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -59,6 +60,17 @@ const HyphensPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Hyphens - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Hyphens utility in Tailwind CSS. Examples and usage details for Hyphens." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Hyphens - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Hyphens utility in Tailwind CSS. Examples and usage details for Hyphens." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/hyphens" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/letter-spacing-page.tsx
+++ b/src/pages/typography/letter-spacing-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -53,6 +54,17 @@ const LetterSpacingPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Letter Spacing - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Letter Spacing utility in Tailwind CSS. Examples and usage details for Letter Spacing." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Letter Spacing - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Letter Spacing utility in Tailwind CSS. Examples and usage details for Letter Spacing." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/letter-spacing" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/line-clamp-page.tsx
+++ b/src/pages/typography/line-clamp-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -52,6 +53,17 @@ const LineClampPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Line Clamp - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Line Clamp utility in Tailwind CSS. Examples and usage details for Line Clamp." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Line Clamp - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Line Clamp utility in Tailwind CSS. Examples and usage details for Line Clamp." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/line-clamp" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/line-height-page.tsx
+++ b/src/pages/typography/line-height-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -75,6 +76,17 @@ const LineHeightPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Line Height - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Line Height utility in Tailwind CSS. Examples and usage details for Line Height." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Line Height - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Line Height utility in Tailwind CSS. Examples and usage details for Line Height." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/line-height" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/list-style-image-page.tsx
+++ b/src/pages/typography/list-style-image-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -50,6 +51,17 @@ const ListStyleImagePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>List Style Image - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the List Style Image utility in Tailwind CSS. Examples and usage details for List Style Image." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="List Style Image - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the List Style Image utility in Tailwind CSS. Examples and usage details for List Style Image." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/list-style-image" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/typography/list-style-position-page.tsx
+++ b/src/pages/typography/list-style-position-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -46,6 +47,17 @@ const ListStylePositionPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>List Style Position - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the List Style Position utility in Tailwind CSS. Examples and usage details for List Style Position." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="List Style Position - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the List Style Position utility in Tailwind CSS. Examples and usage details for List Style Position." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/list-style-position" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/list-style-type-page.tsx
+++ b/src/pages/typography/list-style-type-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -54,6 +55,17 @@ const ListStyleTypePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>List Style Type - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the List Style Type utility in Tailwind CSS. Examples and usage details for List Style Type." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="List Style Type - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the List Style Type utility in Tailwind CSS. Examples and usage details for List Style Type." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/list-style-type" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/text-align-page.tsx
+++ b/src/pages/typography/text-align-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -78,6 +79,17 @@ const TextAlignPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Text Align - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Text Align utility in Tailwind CSS. Examples and usage details for Text Align." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Text Align - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Text Align utility in Tailwind CSS. Examples and usage details for Text Align." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/text-align" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/text-color-page.tsx
+++ b/src/pages/typography/text-color-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -91,6 +92,17 @@ const TextColorPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Text Color - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Text Color utility in Tailwind CSS. Examples and usage details for Text Color." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Text Color - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Text Color utility in Tailwind CSS. Examples and usage details for Text Color." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/text-color" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/text-decoration-color-page.tsx
+++ b/src/pages/typography/text-decoration-color-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -63,6 +64,17 @@ const TextDecorationColorPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Text Decoration Color - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Text Decoration Color utility in Tailwind CSS. Examples and usage details for Text Decoration Color." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Text Decoration Color - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Text Decoration Color utility in Tailwind CSS. Examples and usage details for Text Decoration Color." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/text-decoration-color" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/text-decoration-page.tsx
+++ b/src/pages/typography/text-decoration-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -66,6 +67,17 @@ const TextDecorationPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Text Decoration - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Text Decoration utility in Tailwind CSS. Examples and usage details for Text Decoration." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Text Decoration - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Text Decoration utility in Tailwind CSS. Examples and usage details for Text Decoration." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/text-decoration" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/text-decoration-style-page.tsx
+++ b/src/pages/typography/text-decoration-style-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -69,6 +70,17 @@ const TextDecorationStylePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Text Decoration Style - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Text Decoration Style utility in Tailwind CSS. Examples and usage details for Text Decoration Style." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Text Decoration Style - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Text Decoration Style utility in Tailwind CSS. Examples and usage details for Text Decoration Style." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/text-decoration-style" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/text-decoration-thickness-page.tsx
+++ b/src/pages/typography/text-decoration-thickness-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -54,6 +55,17 @@ const TextDecorationThicknessPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Text Decoration Thickness - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Text Decoration Thickness utility in Tailwind CSS. Examples and usage details for Text Decoration Thickness." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Text Decoration Thickness - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Text Decoration Thickness utility in Tailwind CSS. Examples and usage details for Text Decoration Thickness." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/text-decoration-thickness" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/text-indent-page.tsx
+++ b/src/pages/typography/text-indent-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -62,6 +63,17 @@ const TextIndentPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Text Indent - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Text Indent utility in Tailwind CSS. Examples and usage details for Text Indent." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Text Indent - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Text Indent utility in Tailwind CSS. Examples and usage details for Text Indent." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/text-indent" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/text-overflow-page.tsx
+++ b/src/pages/typography/text-overflow-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -58,6 +59,17 @@ const TextOverflowPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Text Overflow - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Text Overflow utility in Tailwind CSS. Examples and usage details for Text Overflow." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Text Overflow - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Text Overflow utility in Tailwind CSS. Examples and usage details for Text Overflow." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/text-overflow" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/text-transform-page.tsx
+++ b/src/pages/typography/text-transform-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -61,6 +62,17 @@ const TextTransformPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Text Transform - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Text Transform utility in Tailwind CSS. Examples and usage details for Text Transform." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Text Transform - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Text Transform utility in Tailwind CSS. Examples and usage details for Text Transform." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/text-transform" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/text-underline-offset-page.tsx
+++ b/src/pages/typography/text-underline-offset-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -52,6 +53,17 @@ const TextUnderlineOffsetPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Text Underline Offset - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Text Underline Offset utility in Tailwind CSS. Examples and usage details for Text Underline Offset." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Text Underline Offset - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Text Underline Offset utility in Tailwind CSS. Examples and usage details for Text Underline Offset." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/text-underline-offset" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/text-wrap-page.tsx
+++ b/src/pages/typography/text-wrap-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -67,6 +68,17 @@ const TextWrapPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Text Wrap - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Text Wrap utility in Tailwind CSS. Examples and usage details for Text Wrap." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Text Wrap - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Text Wrap utility in Tailwind CSS. Examples and usage details for Text Wrap." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/text-wrap" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/vertical-align-page.tsx
+++ b/src/pages/typography/vertical-align-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import ArticleLayout from '@/components/layout/ArticleLayout';
 import React from 'react';
 
@@ -119,6 +120,17 @@ const VerticalAlignPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Vertical Align - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Vertical Align utility in Tailwind CSS. Examples and usage details for Vertical Align." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Vertical Align - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Vertical Align utility in Tailwind CSS. Examples and usage details for Vertical Align." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/vertical-align" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8">
         {' '}
         {/* 元のCard間のマージンを再現 */}

--- a/src/pages/typography/whitespace-page.tsx
+++ b/src/pages/typography/whitespace-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -104,6 +105,17 @@ const WhitespacePage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Whitespace - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Whitespace utility in Tailwind CSS. Examples and usage details for Whitespace." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Whitespace - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Whitespace utility in Tailwind CSS. Examples and usage details for Whitespace." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/whitespace" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/src/pages/typography/word-break-page.tsx
+++ b/src/pages/typography/word-break-page.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet-async'; // Helmet をインポート
 import React from 'react';
 import ArticleLayout from '@/components/layout/ArticleLayout';
 
@@ -80,6 +81,17 @@ const WordBreakPage: React.FC = () => {
 
   return (
     <ArticleLayout title={title} links={links}>
+
+      <Helmet>
+        <title>Word Break - Tailwind CSS Cheatsheet</title>
+        <meta name="description" content="Learn about the Word Break utility in Tailwind CSS. Examples and usage details for Word Break." />
+        {/* OGP タグ */}
+        <meta property="og:title" content="Word Break - Tailwind CSS Cheatsheet" />
+        <meta property="og:description" content="Learn about the Word Break utility in Tailwind CSS. Examples and usage details for Word Break." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://tKwbr999.github.io/tailwindcss-text/#/typography/word-break" />
+        {/* <meta property="og:image" content="[画像のURL]" /> */} {/* 必要に応じて画像URLを設定 */}
+      </Helmet>
       <div className="space-y-8"> {/* 元のCard間のマージンを再現 */}
         {/* 概要 */}
         <section>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,12 +2,15 @@ import react from '@vitejs/plugin-react-swc';
 import { componentTagger } from 'lovable-tagger';
 import path from 'path'; // path をインポート
 import { defineConfig } from 'vite';
+import viteSitemap from 'vite-plugin-sitemap';
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   // GitHub Pages用のベースパスを設定
   // HashRouterを使用する場合、ベースURLは単純な相対パスでよい
-  const base = process.env.GITHUB_PAGES ? '/go-cheat-sheet-garden/' : './';
+  // tailwindcss-text 用のベースパスに変更
+  const base = process.env.GITHUB_PAGES ? '/tailwindcss-text/' : './';
+  const hostname = process.env.GITHUB_PAGES ? 'https://tKwbr999.github.io/tailwindcss-text/' : 'http://localhost:8080'; // ホスト名も動的に
 
   return {
     base,
@@ -18,7 +21,13 @@ export default defineConfig(({ mode }) => {
       host: '::',
       port: 8080,
     },
-    plugins: [react(), mode === 'development' && componentTagger()].filter(Boolean),
+    plugins: [
+      react(),
+      mode === 'development' && componentTagger(),
+      viteSitemap({
+        hostname: hostname, // 動的に設定
+      }),
+    ].filter(Boolean),
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
This PR implements the basic SEO infrastructure and automatically adds meta tags to page components as planned in issue #35.

**Changes:**

*   **Basic Setup & Technical Foundation (Phase 1):**
    *   Updated `robots.txt` to include the sitemap URL.
    *   Installed and configured `vite-plugin-sitemap` for automatic sitemap generation.
    *   Installed and configured `react-helmet-async` for meta tag management.
    *   Added default `<title>` and `<meta name="description">` in `App.tsx`.
*   **Analysis & Measurement (Phase 3):**
    *   Added Google Search Console verification meta tag to `index.html`.
    *   Added Google Tag Manager snippets (`<script>` and `<noscript>`) to `index.html`.
*   **Content & Structure Optimization (Phase 2 - Partial):**
    *   Created and executed a script (`scripts/add-meta-tags.mjs`) to automatically insert `<Helmet>` tags with basic title, description, and OGP tags into most page components.

**Next Steps (Manual):**

*   Review and refine the automatically generated meta descriptions for key pages.
*   Verify header tag structure (H1, H2, H3) on pages.
*   Verify internal linking structure.
*   Configure Google Analytics tag within the Google Tag Manager console.
*   Perform performance checks (Phase 4).

Closes #35