### PR TITLE
refactor: separatePageTitlesIntoEnAndJa

### DIFF
--- a/src/components/layout/ArticleLayout.tsx
+++ b/src/components/layout/ArticleLayout.tsx
@@ -8,12 +8,13 @@ interface LinkInfo {
 }
 
 interface ArticleLayoutProps {
-  title: string;
+  enTitle: string; // 英語タイトル
+  jaTitle: string; // 日本語タイトル
   links: LinkInfo[];
   children: React.ReactNode;
 }
 
-const ArticleLayout: React.FC<ArticleLayoutProps> = ({ title, links, children }) => {
+const ArticleLayout: React.FC<ArticleLayoutProps> = ({ enTitle, jaTitle, links, children }) => {
   return (
     // ページ全体の背景色とパディング (screen-readers-page.tsxから移動)
     <div className="bg-stone-200 dark:bg-stone-900 min-h-screen p-4 md:p-8 font-serif">
@@ -30,8 +31,9 @@ const ArticleLayout: React.FC<ArticleLayoutProps> = ({ title, links, children })
       {/* コンテンツエリア: 最大幅、中央揃え、背景色、角丸、影 (screen-readers-page.tsxから移動) */}
       <div className="max-w-4xl mx-auto bg-stone-100 dark:bg-stone-800 rounded-lg shadow-md p-6 space-y-8">
         {/* ページタイトル */}
-        <h1 className="text-3xl font-bold text-center text-stone-900 dark:text-stone-100">
-          {title}
+        <h1 className="text-3xl font-bold text-center text-stone-900 dark:text-stone-100 leading-tight">
+          <span className="block">{enTitle}</span>
+          <span className="block text-lg font-medium">{jaTitle}</span> {/* 日本語は少し小さく */}
         </h1>
         {/* 参照リンク */}
         <ReferenceLinks links={links} />

--- a/src/pages/accessibility/screen-readers-page.tsx
+++ b/src/pages/accessibility/screen-readers-page.tsx
@@ -32,7 +32,8 @@ const ScreenReadersExample: React.FC = () => {
 // ページコンポーネント本体
 const ScreenReadersPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Accessibility: Screen Readers (スクリーンリーダー)';
+  const enTitle = 'Accessibility: Screen Readers ';
+const jaTitle = 'スクリーンリーダー';
   const links = [
     {
       title: 'Tailwind CSS: Screen Readers',
@@ -169,7 +170,7 @@ const ScreenReadersPage: React.FC = () => {
   );
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Screen Readers - Tailwind CSS Cheatsheet</title>

--- a/src/pages/backgrounds/background-attachment-page.tsx
+++ b/src/pages/backgrounds/background-attachment-page.tsx
@@ -86,7 +86,8 @@ const BgScrollExample: React.FC = () => {
 // ページコンポーネント本体
 const BackgroundAttachmentPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Backgrounds: Background Attachment (背景の固定)';
+  const enTitle = 'Backgrounds: Background Attachment ';
+const jaTitle = '背景の固定';
   const links = [
     {
       title: 'Tailwind CSS: Background Attachment',
@@ -104,7 +105,7 @@ const BackgroundAttachmentPage: React.FC = () => {
   const bgScrollHtml = `<div class="bg-scroll bg-cover bg-center h-48 overflow-auto ..." style="background-image: url(...)">...</div>`; // Default
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Background Attachment - Tailwind CSS Cheatsheet</title>

--- a/src/pages/backgrounds/background-clip-page.tsx
+++ b/src/pages/backgrounds/background-clip-page.tsx
@@ -51,7 +51,8 @@ const BgClipTextExample: React.FC = () => {
 // ページコンポーネント本体
 const BackgroundClipPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Backgrounds: Background Clip (背景のクリッピング領域)';
+  const enTitle = 'Backgrounds: Background Clip ';
+const jaTitle = '背景のクリッピング領域';
   const links = [
     {
       title: 'Tailwind CSS: Background Clip',
@@ -70,7 +71,7 @@ const BackgroundClipPage: React.FC = () => {
   const clipTextHtml = `<span class="bg-clip-text text-transparent bg-gradient-to-r ...">...</span>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Background Clip - Tailwind CSS Cheatsheet</title>

--- a/src/pages/backgrounds/background-color-page.tsx
+++ b/src/pages/backgrounds/background-color-page.tsx
@@ -61,7 +61,8 @@ const ArbitraryBgColorExample: React.FC = () => {
 // ページコンポーネント本体
 const BackgroundColorPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Backgrounds: Background Color (背景色)';
+  const enTitle = 'Backgrounds: Background Color ';
+const jaTitle = '背景色';
   const links = [
     {
       title: 'Tailwind CSS: Background Color',
@@ -87,7 +88,7 @@ const BackgroundColorPage: React.FC = () => {
   const arbitraryBgColorHtml = `<div class="bg-[#ff7f50] ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Background Color - Tailwind CSS Cheatsheet</title>

--- a/src/pages/backgrounds/background-image-page.tsx
+++ b/src/pages/backgrounds/background-image-page.tsx
@@ -57,7 +57,8 @@ const ArbitraryGradientExample: React.FC = () => {
 // ページコンポーネント本体
 const BackgroundImagePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Backgrounds: Background Image (背景画像)';
+  const enTitle = 'Backgrounds: Background Image ';
+const jaTitle = '背景画像';
   const links = [
     {
       title: 'Tailwind CSS: Background Image',
@@ -83,7 +84,7 @@ const BackgroundImagePage: React.FC = () => {
   const arbitraryGradientHtml = `<div class="bg-[linear-gradient(...)] ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Background Image - Tailwind CSS Cheatsheet</title>

--- a/src/pages/backgrounds/background-origin-page.tsx
+++ b/src/pages/backgrounds/background-origin-page.tsx
@@ -50,7 +50,8 @@ const BgOriginContentExample: React.FC = () => {
 // ページコンポーネント本体
 const BackgroundOriginPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Backgrounds: Background Origin (背景画像の原点)';
+  const enTitle = 'Backgrounds: Background Origin ';
+const jaTitle = '背景画像の原点';
   const links = [
     {
       title: 'Tailwind CSS: Background Origin',
@@ -68,7 +69,7 @@ const BackgroundOriginPage: React.FC = () => {
   const originContentHtml = `<div class="bg-origin-content p-6 border-8 bg-center bg-no-repeat ..." style="background-image: url(...)">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Background Origin - Tailwind CSS Cheatsheet</title>

--- a/src/pages/backgrounds/background-position-page.tsx
+++ b/src/pages/backgrounds/background-position-page.tsx
@@ -85,7 +85,8 @@ const ArbitraryPositionExample: React.FC = () => {
 // ページコンポーネント本体
 const BackgroundPositionPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Backgrounds: Background Position (背景画像の位置)';
+  const enTitle = 'Backgrounds: Background Position ';
+const jaTitle = '背景画像の位置';
   const links = [
     {
       title: 'Tailwind CSS: Background Position',
@@ -107,7 +108,7 @@ const BackgroundPositionPage: React.FC = () => {
   const arbitraryPosHtml = `<div class="bg-[position:25%_75%] bg-no-repeat ..." style="background-image: url(...)">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Background Position - Tailwind CSS Cheatsheet</title>

--- a/src/pages/backgrounds/background-repeat-page.tsx
+++ b/src/pages/backgrounds/background-repeat-page.tsx
@@ -99,7 +99,8 @@ const BgRepeatSpaceExample: React.FC = () => {
 // ページコンポーネント本体
 const BackgroundRepeatPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Backgrounds: Background Repeat (背景画像の繰り返し)';
+  const enTitle = 'Backgrounds: Background Repeat ';
+const jaTitle = '背景画像の繰り返し';
   const links = [
     {
       title: 'Tailwind CSS: Background Repeat',
@@ -120,7 +121,7 @@ const BackgroundRepeatPage: React.FC = () => {
   const bgRepeatSpaceHtml = `<div class="bg-repeat-space ..." style="background-image: url(...)">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Background Repeat - Tailwind CSS Cheatsheet</title>

--- a/src/pages/backgrounds/background-size-page.tsx
+++ b/src/pages/backgrounds/background-size-page.tsx
@@ -68,7 +68,8 @@ const ArbitrarySizeExample: React.FC = () => {
 // ページコンポーネント本体
 const BackgroundSizePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Backgrounds: Background Size (背景画像のサイズ)';
+  const enTitle = 'Backgrounds: Background Size ';
+const jaTitle = '背景画像のサイズ';
   const links = [
     {
       title: 'Tailwind CSS: Background Size',
@@ -87,7 +88,7 @@ const BackgroundSizePage: React.FC = () => {
   const arbitrarySizeHtml = `<div class="bg-[length:50%_75%] bg-no-repeat ..." style="background-image: url(...)">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Background Size - Tailwind CSS Cheatsheet</title>

--- a/src/pages/backgrounds/gradient-color-stops-page.tsx
+++ b/src/pages/backgrounds/gradient-color-stops-page.tsx
@@ -26,7 +26,8 @@ const GradientStopsExample: React.FC = () => {
 // ページコンポーネント本体
 const GradientColorStopsPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Backgrounds: Gradient Color Stops (グラデーションの色停止点)';
+  const enTitle = 'Backgrounds: Gradient Color Stops ';
+const jaTitle = 'グラデーションの色停止点';
   const links = [
     {
       title: 'Tailwind CSS: Gradient Color Stops',
@@ -51,7 +52,7 @@ const GradientColorStopsPage: React.FC = () => {
   const gradientOpacityHtml = `<div class="bg-gradient-to-r from-yellow-400/50 via-red-500/75 to-rose-600 ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Gradient Color Stops - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/border-color-page.tsx
+++ b/src/pages/borders/border-color-page.tsx
@@ -87,7 +87,8 @@ const ArbitraryBorderColorExample: React.FC = () => {
 // ページコンポーネント本体
 const BorderColorPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Border Color (境界線の色)';
+  const enTitle = 'Borders: Border Color ';
+const jaTitle = '境界線の色';
   const links = [
     {
       title: 'Tailwind CSS: Border Color',
@@ -121,7 +122,7 @@ const BorderColorPage: React.FC = () => {
   const arbitraryBorderColorHtml = `<div class="border-4 border-[#ff7f50] ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Border Color - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/border-radius-page.tsx
+++ b/src/pages/borders/border-radius-page.tsx
@@ -94,7 +94,8 @@ const ArbitraryRadiusExample: React.FC = () => {
 // ページコンポーネント本体
 const BorderRadiusPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Border Radius (角丸)';
+  const enTitle = 'Borders: Border Radius ';
+const jaTitle = '角丸';
   const links = [
     {
       title: 'Tailwind CSS: Border Radius',
@@ -138,7 +139,7 @@ const BorderRadiusPage: React.FC = () => {
   const arbitraryRadiusHtml = `<div class="rounded-[10px] ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Border Radius - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/border-style-page.tsx
+++ b/src/pages/borders/border-style-page.tsx
@@ -33,7 +33,8 @@ const BorderStyleExample: React.FC = () => {
 // ページコンポーネント本体
 const BorderStylePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Border Style (境界線のスタイル)';
+  const enTitle = 'Borders: Border Style ';
+const jaTitle = '境界線のスタイル';
   const links = [
     {
       title: 'Tailwind CSS: Border Style',
@@ -56,7 +57,7 @@ const BorderStylePage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Border Style - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/border-width-page.tsx
+++ b/src/pages/borders/border-width-page.tsx
@@ -48,7 +48,8 @@ const ArbitraryWidthExample: React.FC = () => {
 // ページコンポーネント本体
 const BorderWidthPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Border Width (境界線の太さ)';
+  const enTitle = 'Borders: Border Width ';
+const jaTitle = '境界線の太さ';
   const links = [
     {
       title: 'Tailwind CSS: Border Width',
@@ -84,7 +85,7 @@ const BorderWidthPage: React.FC = () => {
   const arbitraryWidthHtml = `<div class="border-[3px] ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Border Width - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/divide-color-page.tsx
+++ b/src/pages/borders/divide-color-page.tsx
@@ -55,7 +55,8 @@ const DivideCurrentInheritTransparentExample: React.FC = () => {
 // ページコンポーネント本体
 const DivideColorPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Divide Color (要素間の境界線の色)';
+  const enTitle = 'Borders: Divide Color ';
+const jaTitle = '要素間の境界線の色';
   const links = [
     {
       title: 'Tailwind CSS: Divide Color',
@@ -82,7 +83,7 @@ const DivideColorPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Divide Color - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/divide-style-page.tsx
+++ b/src/pages/borders/divide-style-page.tsx
@@ -66,7 +66,8 @@ const DivideNoneExample: React.FC = () => {
 // ページコンポーネント本体
 const DivideStylePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Divide Style (要素間の境界線のスタイル)';
+  const enTitle = 'Borders: Divide Style ';
+const jaTitle = '要素間の境界線のスタイル';
   const links = [
     {
       title: 'Tailwind CSS: Divide Style',
@@ -86,7 +87,7 @@ const DivideStylePage: React.FC = () => {
   const divideNoneHtml = `<div class="flex divide-x-4 divide-none ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Divide Style - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/divide-width-page.tsx
+++ b/src/pages/borders/divide-width-page.tsx
@@ -52,7 +52,8 @@ const ArbitraryDivideWidthExample: React.FC = () => {
 // ページコンポーネント本体
 const DivideWidthPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Divide Width (要素間の境界線の太さ)';
+  const enTitle = 'Borders: Divide Width ';
+const jaTitle = '要素間の境界線の太さ';
   const links = [
     {
       title: 'Tailwind CSS: Divide Width',
@@ -89,7 +90,7 @@ const DivideWidthPage: React.FC = () => {
   const arbitraryDivideWidthHtml = `<div class="flex divide-x-[3px] divide-purple-500 ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Divide Width - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/outline-color-page.tsx
+++ b/src/pages/borders/outline-color-page.tsx
@@ -72,7 +72,8 @@ const ArbitraryOutlineColorExample: React.FC = () => {
 // ページコンポーネント本体
 const OutlineColorPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Outline Color (アウトラインの色)';
+  const enTitle = 'Borders: Outline Color ';
+const jaTitle = 'アウトラインの色';
   const links = [
     {
       title: 'Tailwind CSS: Outline Color',
@@ -95,7 +96,7 @@ const OutlineColorPage: React.FC = () => {
   const arbitraryOutlineColorHtml = `<button class="outline outline-2 outline-[#ff7f50] ...">...</button>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Outline Color - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/outline-offset-page.tsx
+++ b/src/pages/borders/outline-offset-page.tsx
@@ -38,7 +38,8 @@ const ArbitraryOutlineOffsetExample: React.FC = () => {
 // ページコンポーネント本体
 const OutlineOffsetPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Outline Offset (アウトラインのオフセット)';
+  const enTitle = 'Borders: Outline Offset ';
+const jaTitle = 'アウトラインのオフセット';
   const links = [
     {
       title: 'Tailwind CSS: Outline Offset',
@@ -61,7 +62,7 @@ const OutlineOffsetPage: React.FC = () => {
   const arbitraryOutlineOffsetHtml = `<button class="outline outline-2 outline-offset-[3px] ...">...</button>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Outline Offset - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/outline-style-page.tsx
+++ b/src/pages/borders/outline-style-page.tsx
@@ -47,7 +47,8 @@ const OutlineDoubleExample: React.FC = () => {
 // ページコンポーネント本体
 const OutlineStylePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Outline Style (アウトラインのスタイル)';
+  const enTitle = 'Borders: Outline Style ';
+const jaTitle = 'アウトラインのスタイル';
   const links = [
     {
       title: 'Tailwind CSS: Outline Style',
@@ -67,7 +68,7 @@ const OutlineStylePage: React.FC = () => {
   const outlineDoubleHtml = `<button class="outline-double outline-4 ...">...</button>`; // Needs sufficient width
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Outline Style - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/outline-width-page.tsx
+++ b/src/pages/borders/outline-width-page.tsx
@@ -28,7 +28,8 @@ const ArbitraryOutlineWidthExample: React.FC = () => {
 // ページコンポーネント本体
 const OutlineWidthPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Outline Width (アウトラインの太さ)';
+  const enTitle = 'Borders: Outline Width ';
+const jaTitle = 'アウトラインの太さ';
   const links = [
     {
       title: 'Tailwind CSS: Outline Width',
@@ -51,7 +52,7 @@ const OutlineWidthPage: React.FC = () => {
   const arbitraryOutlineWidthHtml = `<button class="outline outline-[3px] ...">...</button>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Outline Width - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/ring-color-page.tsx
+++ b/src/pages/borders/ring-color-page.tsx
@@ -57,7 +57,8 @@ const ArbitraryRingColorExample: React.FC = () => {
 // ページコンポーネント本体
 const RingColorPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Ring Color (リングの色)';
+  const enTitle = 'Borders: Ring Color ';
+const jaTitle = 'リングの色';
   const links = [
     {
       title: 'Tailwind CSS: Ring Color',
@@ -80,7 +81,7 @@ const RingColorPage: React.FC = () => {
   const arbitraryRingColorHtml = `<button class="ring ring-[#ff7f50] ...">...</button>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Ring Color - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/ring-offset-color-page.tsx
+++ b/src/pages/borders/ring-offset-color-page.tsx
@@ -45,7 +45,8 @@ const ArbitraryRingOffsetColorExample: React.FC = () => {
 // ページコンポーネント本体
 const RingOffsetColorPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Ring Offset Color (リングオフセットの色)';
+  const enTitle = 'Borders: Ring Offset Color ';
+const jaTitle = 'リングオフセットの色';
   const links = [
     {
       title: 'Tailwind CSS: Ring Offset Color',
@@ -62,7 +63,7 @@ const RingOffsetColorPage: React.FC = () => {
   const arbitraryRingOffsetColorHtml = `<button class="ring ring-offset-4 ring-offset-[#ff7f50] ...">...</button>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Ring Offset Color - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/ring-offset-width-page.tsx
+++ b/src/pages/borders/ring-offset-width-page.tsx
@@ -42,7 +42,8 @@ const ArbitraryRingOffsetWidthExample: React.FC = () => {
 // ページコンポーネント本体
 const RingOffsetWidthPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Ring Offset Width (リングオフセットの太さ)';
+  const enTitle = 'Borders: Ring Offset Width ';
+const jaTitle = 'リングオフセットの太さ';
   const links = [
     {
       title: 'Tailwind CSS: Ring Offset Width',
@@ -65,7 +66,7 @@ const RingOffsetWidthPage: React.FC = () => {
   const arbitraryRingOffsetWidthHtml = `<button class="ring ring-offset-[3px] ring-offset-white ...">...</button>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Ring Offset Width - Tailwind CSS Cheatsheet</title>

--- a/src/pages/borders/ring-width-page.tsx
+++ b/src/pages/borders/ring-width-page.tsx
@@ -38,7 +38,8 @@ const ArbitraryRingWidthExample: React.FC = () => {
 // ページコンポーネント本体
 const RingWidthPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Borders: Ring Width (リングの太さ)';
+  const enTitle = 'Borders: Ring Width ';
+const jaTitle = 'リングの太さ';
   const links = [
     {
       title: 'Tailwind CSS: Ring Width',
@@ -63,7 +64,7 @@ const RingWidthPage: React.FC = () => {
   const arbitraryRingWidthHtml = `<button class="ring ring-[3px] ...">...</button>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Ring Width - Tailwind CSS Cheatsheet</title>

--- a/src/pages/effects/background-blend-mode-page.tsx
+++ b/src/pages/effects/background-blend-mode-page.tsx
@@ -26,7 +26,8 @@ const BgBlendModeExample: React.FC<{ blendMode: string; label: string }> = ({
 // ページコンポーネント本体
 const BackgroundBlendModePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Effects: Background Blend Mode (背景ブレンドモード)';
+  const enTitle = 'Effects: Background Blend Mode ';
+const jaTitle = '背景ブレンドモード';
   const links = [
     {
       title: 'Tailwind CSS: Background Blend Mode',
@@ -45,7 +46,7 @@ const BackgroundBlendModePage: React.FC = () => {
   // const blendOverlayHtml = `<div class="bg-blend-overlay bg-blue-500 bg-center bg-cover ..." style="background-image: url(...)">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Background Blend Mode - Tailwind CSS Cheatsheet</title>

--- a/src/pages/effects/box-shadow-color-page.tsx
+++ b/src/pages/effects/box-shadow-color-page.tsx
@@ -41,7 +41,8 @@ const ArbitraryShadowColorExample: React.FC = () => {
 // ページコンポーネント本体
 const BoxShadowColorPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Effects: Box Shadow Color (ボックスシャドウの色)';
+  const enTitle = 'Effects: Box Shadow Color ';
+const jaTitle = 'ボックスシャドウの色';
   const links = [
     {
       title: 'Tailwind CSS: Box Shadow Color (v3.0+)',
@@ -65,7 +66,7 @@ const BoxShadowColorPage: React.FC = () => {
   const arbitraryShadowColorHtml = `<div class="shadow-lg shadow-[#ff7f50]/60 ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Box Shadow Color - Tailwind CSS Cheatsheet</title>

--- a/src/pages/effects/box-shadow-page.tsx
+++ b/src/pages/effects/box-shadow-page.tsx
@@ -46,7 +46,8 @@ const ArbitraryShadowExample: React.FC = () => {
 // ページコンポーネント本体
 const BoxShadowPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Effects: Box Shadow (ボックスシャドウ)';
+  const enTitle = 'Effects: Box Shadow ';
+const jaTitle = 'ボックスシャドウ';
   const links = [
     {
       title: 'Tailwind CSS: Box Shadow',
@@ -76,7 +77,7 @@ const BoxShadowPage: React.FC = () => {
   const arbitraryShadowHtml = `<div class="shadow-[0_10px_20px_rgba(240,_46,_170,_0.7)] ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Box Shadow - Tailwind CSS Cheatsheet</title>

--- a/src/pages/effects/mix-blend-mode-page.tsx
+++ b/src/pages/effects/mix-blend-mode-page.tsx
@@ -30,7 +30,8 @@ const BlendModeExample: React.FC<{ blendMode: string; label: string }> = ({ blen
 // ページコンポーネント本体
 const MixBlendModePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Effects: Mix Blend Mode (混合ブレンドモード)';
+  const enTitle = 'Effects: Mix Blend Mode ';
+const jaTitle = '混合ブレンドモード';
   const links = [
     {
       title: 'Tailwind CSS: Mix Blend Mode',
@@ -49,7 +50,7 @@ const MixBlendModePage: React.FC = () => {
   // const blendNormalHtml = `<div class="mix-blend-normal ...">...</div>`; // Default
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Mix Blend Mode - Tailwind CSS Cheatsheet</title>

--- a/src/pages/effects/opacity-page.tsx
+++ b/src/pages/effects/opacity-page.tsx
@@ -37,7 +37,8 @@ const ArbitraryOpacityExample: React.FC = () => {
 // ページコンポーネント本体
 const OpacityPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Effects: Opacity (不透明度)';
+  const enTitle = 'Effects: Opacity ';
+const jaTitle = '不透明度';
   const links = [
     {
       title: 'Tailwind CSS: Opacity',
@@ -60,7 +61,7 @@ const OpacityPage: React.FC = () => {
   const arbitraryOpacityHtml = `<div class="opacity-[.65] ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Opacity - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/backdrop-blur-page.tsx
+++ b/src/pages/filters/backdrop-blur-page.tsx
@@ -83,7 +83,8 @@ const ArbitraryBackdropBlurExample: React.FC = () => {
 // ページコンポーネント本体
 const BackdropBlurPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Backdrop Blur (背景ぼかし)';
+  const enTitle = 'Filters: Backdrop Blur ';
+const jaTitle = '背景ぼかし';
   const links = [
     {
       title: 'Tailwind CSS: Backdrop Blur',
@@ -109,7 +110,7 @@ const BackdropBlurPage: React.FC = () => {
   const arbitraryBackdropBlurHtml = `<div class="backdrop-blur-[2px] ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Backdrop Blur - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/backdrop-brightness-page.tsx
+++ b/src/pages/filters/backdrop-brightness-page.tsx
@@ -80,7 +80,8 @@ const ArbitraryBackdropBrightnessExample: React.FC = () => {
 // ページコンポーネント本体
 const BackdropBrightnessPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Backdrop Brightness (背景の明るさ)';
+  const enTitle = 'Filters: Backdrop Brightness ';
+const jaTitle = '背景の明るさ';
   const links = [
     {
       title: 'Tailwind CSS: Backdrop Brightness',
@@ -105,7 +106,7 @@ const BackdropBrightnessPage: React.FC = () => {
   const arbitraryBackdropBrightnessHtml = `<div class="backdrop-brightness-[.65] ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Backdrop Brightness - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/backdrop-contrast-page.tsx
+++ b/src/pages/filters/backdrop-contrast-page.tsx
@@ -78,7 +78,8 @@ const ArbitraryBackdropContrastExample: React.FC = () => {
 // ページコンポーネント本体
 const BackdropContrastPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Backdrop Contrast (背景コントラスト)';
+  const enTitle = 'Filters: Backdrop Contrast ';
+const jaTitle = '背景コントラスト';
   const links = [
     {
       title: 'Tailwind CSS: Backdrop Contrast',
@@ -103,7 +104,7 @@ const BackdropContrastPage: React.FC = () => {
   const arbitraryBackdropContrastHtml = `<div class="backdrop-contrast-[.85] ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Backdrop Contrast - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/backdrop-grayscale-page.tsx
+++ b/src/pages/filters/backdrop-grayscale-page.tsx
@@ -55,7 +55,8 @@ const ArbitraryBackdropGrayscaleExample: React.FC = () => {
 // ページコンポーネント本体
 const BackdropGrayscalePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Backdrop Grayscale (背景グレースケール)';
+  const enTitle = 'Filters: Backdrop Grayscale ';
+const jaTitle = '背景グレースケール';
   const links = [
     {
       title: 'Tailwind CSS: Backdrop Grayscale',
@@ -79,7 +80,7 @@ const BackdropGrayscalePage: React.FC = () => {
   const arbitraryBackdropGrayscaleHtml = `<div class="backdrop-filter backdrop-grayscale-[50%] ...">...</div> {/* Requires JIT & backdrop-filter enabled */} `;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Backdrop Grayscale - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/backdrop-hue-rotate-page.tsx
+++ b/src/pages/filters/backdrop-hue-rotate-page.tsx
@@ -76,7 +76,8 @@ const ArbitraryBackdropHueRotateExample: React.FC = () => {
 // ページコンポーネント本体
 const BackdropHueRotatePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Backdrop Hue Rotate (背景の色相回転)';
+  const enTitle = 'Filters: Backdrop Hue Rotate ';
+const jaTitle = '背景の色相回転';
   const links = [
     {
       title: 'Tailwind CSS: Backdrop Hue Rotate',
@@ -102,7 +103,7 @@ const BackdropHueRotatePage: React.FC = () => {
   const arbitraryBackdropHueRotateHtml = `<div class="backdrop-filter backdrop-hue-rotate-[270deg] ...">...</div> {/* Requires JIT & backdrop-filter enabled */} `;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Backdrop Hue Rotate - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/backdrop-invert-page.tsx
+++ b/src/pages/filters/backdrop-invert-page.tsx
@@ -55,7 +55,8 @@ const ArbitraryBackdropInvertExample: React.FC = () => {
 // ページコンポーネント本体
 const BackdropInvertPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Backdrop Invert (背景の色反転)';
+  const enTitle = 'Filters: Backdrop Invert ';
+const jaTitle = '背景の色反転';
   const links = [
     {
       title: 'Tailwind CSS: Backdrop Invert',
@@ -79,7 +80,7 @@ const BackdropInvertPage: React.FC = () => {
   const arbitraryBackdropInvertHtml = `<div class="backdrop-filter backdrop-invert-[.75] ...">...</div> {/* Requires JIT & backdrop-filter enabled */} `;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Backdrop Invert - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/backdrop-opacity-page.tsx
+++ b/src/pages/filters/backdrop-opacity-page.tsx
@@ -75,7 +75,8 @@ const ArbitraryBackdropOpacityExample: React.FC = () => {
 // ページコンポーネント本体
 const BackdropOpacityPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Backdrop Opacity (背景の不透明度)';
+  const enTitle = 'Filters: Backdrop Opacity ';
+const jaTitle = '背景の不透明度';
   const links = [
     {
       title: 'Tailwind CSS: Backdrop Opacity',
@@ -99,7 +100,7 @@ const BackdropOpacityPage: React.FC = () => {
   const arbitraryBackdropOpacityHtml = `<div class="backdrop-filter backdrop-opacity-[.65] bg-white/30 ...">...</div> {/* Requires JIT & backdrop-filter enabled */} `;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Backdrop Opacity - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/backdrop-saturate-page.tsx
+++ b/src/pages/filters/backdrop-saturate-page.tsx
@@ -69,7 +69,8 @@ const ArbitraryBackdropSaturateExample: React.FC = () => {
 // ページコンポーネント本体
 const BackdropSaturatePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Backdrop Saturate (背景の彩度)';
+  const enTitle = 'Filters: Backdrop Saturate ';
+const jaTitle = '背景の彩度';
   const links = [
     {
       title: 'Tailwind CSS: Backdrop Saturate',
@@ -94,7 +95,7 @@ const BackdropSaturatePage: React.FC = () => {
   const arbitraryBackdropSaturateHtml = `<div class="backdrop-filter backdrop-saturate-[.85] ...">...</div> {/* Requires JIT & backdrop-filter enabled */} `;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Backdrop Saturate - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/backdrop-sepia-page.tsx
+++ b/src/pages/filters/backdrop-sepia-page.tsx
@@ -55,7 +55,8 @@ const ArbitraryBackdropSepiaExample: React.FC = () => {
 // ページコンポーネント本体
 const BackdropSepiaPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Backdrop Sepia (背景セピア)';
+  const enTitle = 'Filters: Backdrop Sepia ';
+const jaTitle = '背景セピア';
   const links = [
     {
       title: 'Tailwind CSS: Backdrop Sepia',
@@ -79,7 +80,7 @@ const BackdropSepiaPage: React.FC = () => {
   const arbitraryBackdropSepiaHtml = `<div class="backdrop-filter backdrop-sepia-[.65] ...">...</div> {/* Requires JIT & backdrop-filter enabled */} `;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Backdrop Sepia - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/blur-page.tsx
+++ b/src/pages/filters/blur-page.tsx
@@ -31,7 +31,8 @@ const ArbitraryBlurExample: React.FC = () => {
 // ページコンポーネント本体
 const BlurPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Blur (ぼかし)';
+  const enTitle = 'Filters: Blur ';
+const jaTitle = 'ぼかし';
   const links = [
     {
       title: 'Tailwind CSS: Blur',
@@ -57,7 +58,7 @@ const BlurPage: React.FC = () => {
   const arbitraryBlurHtml = `<img class="blur-[2px] ..." src="..." alt="...">`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Blur - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/brightness-page.tsx
+++ b/src/pages/filters/brightness-page.tsx
@@ -33,7 +33,8 @@ const ArbitraryBrightnessExample: React.FC = () => {
 // ページコンポーネント本体
 const BrightnessPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Brightness (明るさ)';
+  const enTitle = 'Filters: Brightness ';
+const jaTitle = '明るさ';
   const links = [
     {
       title: 'Tailwind CSS: Brightness',
@@ -56,7 +57,7 @@ const BrightnessPage: React.FC = () => {
   const arbitraryBrightnessHtml = `<img class="brightness-[.65] ..." src="..." alt="...">`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Brightness - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/contrast-page.tsx
+++ b/src/pages/filters/contrast-page.tsx
@@ -30,7 +30,8 @@ const ArbitraryContrastExample: React.FC = () => {
 // ページコンポーネント本体
 const ContrastPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Contrast (コントラスト)';
+  const enTitle = 'Filters: Contrast ';
+const jaTitle = 'コントラスト';
   const links = [
     {
       title: 'Tailwind CSS: Contrast',
@@ -53,7 +54,7 @@ const ContrastPage: React.FC = () => {
   const arbitraryContrastHtml = `<img class="contrast-[.85] ..." src="..." alt="...">`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Contrast - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/drop-shadow-page.tsx
+++ b/src/pages/filters/drop-shadow-page.tsx
@@ -67,7 +67,8 @@ const ArbitraryDropShadowExample: React.FC = () => {
 // ページコンポーネント本体
 const DropShadowPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Drop Shadow (ドロップシャドウ)';
+  const enTitle = 'Filters: Drop Shadow ';
+const jaTitle = 'ドロップシャドウ';
   const links = [
     {
       title: 'Tailwind CSS: Drop Shadow',
@@ -92,7 +93,7 @@ const DropShadowPage: React.FC = () => {
   const arbitraryDropShadowHtml = `<img class="drop-shadow-[0_4px_3px_rgba(0,0,0,0.5)] ..." src="..." alt="...">`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Drop Shadow - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/grayscale-page.tsx
+++ b/src/pages/filters/grayscale-page.tsx
@@ -35,7 +35,8 @@ const ArbitraryGrayscaleExample: React.FC = () => {
 // ページコンポーネント本体
 const GrayscalePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Grayscale (グレースケール)';
+  const enTitle = 'Filters: Grayscale ';
+const jaTitle = 'グレースケール';
   const links = [
     {
       title: 'Tailwind CSS: Grayscale',
@@ -55,7 +56,7 @@ const GrayscalePage: React.FC = () => {
   const arbitraryGrayscaleHtml = `<img class="filter grayscale-[50%] ..." src="..." alt="..."> {/* Requires JIT & filter enabled */} `;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Grayscale - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/hue-rotate-page.tsx
+++ b/src/pages/filters/hue-rotate-page.tsx
@@ -31,7 +31,8 @@ const ArbitraryHueRotateExample: React.FC = () => {
 // ページコンポーネント本体
 const HueRotatePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Hue Rotate (色相回転)';
+  const enTitle = 'Filters: Hue Rotate ';
+const jaTitle = '色相回転';
   const links = [
     {
       title: 'Tailwind CSS: Hue Rotate',
@@ -55,7 +56,7 @@ const HueRotatePage: React.FC = () => {
   const arbitraryHueRotateHtml = `<img class="hue-rotate-[270deg] ..." src="..." alt="...">`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Hue Rotate - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/invert-page.tsx
+++ b/src/pages/filters/invert-page.tsx
@@ -33,7 +33,8 @@ const ArbitraryInvertExample: React.FC = () => {
 // ページコンポーネント本体
 const InvertPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Invert (色反転)';
+  const enTitle = 'Filters: Invert ';
+const jaTitle = '色反転';
   const links = [
     {
       title: 'Tailwind CSS: Invert',
@@ -53,7 +54,7 @@ const InvertPage: React.FC = () => {
   const arbitraryInvertHtml = `<img class="filter invert-[.75] ..." src="..." alt="..."> {/* Requires JIT & filter enabled */} `;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Invert - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/saturate-page.tsx
+++ b/src/pages/filters/saturate-page.tsx
@@ -28,7 +28,8 @@ const ArbitrarySaturateExample: React.FC = () => {
 // ページコンポーネント本体
 const SaturatePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Saturate (彩度)';
+  const enTitle = 'Filters: Saturate ';
+const jaTitle = '彩度';
   const links = [
     {
       title: 'Tailwind CSS: Saturate',
@@ -51,7 +52,7 @@ const SaturatePage: React.FC = () => {
   const arbitrarySaturateHtml = `<img class="saturate-[.85] ..." src="..." alt="...">`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Saturate - Tailwind CSS Cheatsheet</title>

--- a/src/pages/filters/sepia-page.tsx
+++ b/src/pages/filters/sepia-page.tsx
@@ -29,7 +29,8 @@ const ArbitrarySepiaExample: React.FC = () => {
 // ページコンポーネント本体
 const SepiaPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Filters: Sepia (セピア)';
+  const enTitle = 'Filters: Sepia ';
+const jaTitle = 'セピア';
   const links = [
     {
       title: 'Tailwind CSS: Sepia',
@@ -49,7 +50,7 @@ const SepiaPage: React.FC = () => {
   const arbitrarySepiaHtml = `<img class="filter sepia-[.65] ..." src="..." alt="..."> {/* Requires JIT & filter enabled */} `;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Sepia - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/align-content-page.tsx
+++ b/src/pages/flexbox-grid/align-content-page.tsx
@@ -173,7 +173,8 @@ const ContentStretchExample: React.FC = () => {
 // ページコンポーネント本体
 const AlignContentPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Align Content (複数行/列の交差軸揃え)';
+  const enTitle = 'Flexbox & Grid: Align Content ';
+const jaTitle = '複数行/列の交差軸揃え';
   const links = [
     {
       title: 'Tailwind CSS: Align Content',
@@ -195,7 +196,7 @@ const AlignContentPage: React.FC = () => {
   const contentStretchHtml = `<div class="flex flex-wrap content-stretch h-48 ...">...</div>`; // v3.3+
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Align Content - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/align-items-page.tsx
+++ b/src/pages/flexbox-grid/align-items-page.tsx
@@ -68,7 +68,8 @@ const ItemsStretchExample: React.FC = () => {
 // ページコンポーネント本体
 const AlignItemsPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Align Items (アイテムの交差軸揃え)';
+  const enTitle = 'Flexbox & Grid: Align Items ';
+const jaTitle = 'アイテムの交差軸揃え';
   const links = [
     {
       title: 'Tailwind CSS: Align Items',
@@ -88,7 +89,7 @@ const AlignItemsPage: React.FC = () => {
   const itemsStretchHtml = `<div class="flex items-stretch h-24 ...">...</div>`; // Default
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Align Items - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/align-self-page.tsx
+++ b/src/pages/flexbox-grid/align-self-page.tsx
@@ -30,7 +30,8 @@ const AlignSelfExample: React.FC = () => {
 // ページコンポーネント本体
 const AlignSelfPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Align Self (個別アイテムの交差軸揃え)';
+  const enTitle = 'Flexbox & Grid: Align Self ';
+const jaTitle = '個別アイテムの交差軸揃え';
   const links = [
     {
       title: 'Tailwind CSS: Align Self',
@@ -51,7 +52,7 @@ const AlignSelfPage: React.FC = () => {
   // const selfAutoHtml = `<div class="self-auto ...">Item</div>`; // Inherits parent's align-items
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Align Self - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/flex-basis-page.tsx
+++ b/src/pages/flexbox-grid/flex-basis-page.tsx
@@ -61,7 +61,8 @@ const BasisFullExample: React.FC = () => {
 // ページコンポーネント本体
 const FlexBasisPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Flex Basis (フレックス基準サイズ)';
+  const enTitle = 'Flexbox & Grid: Flex Basis ';
+const jaTitle = 'フレックス基準サイズ';
   const links = [
     {
       title: 'Tailwind CSS: Flex Basis',
@@ -108,7 +109,7 @@ const FlexBasisPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Flex Basis - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/flex-direction-page.tsx
+++ b/src/pages/flexbox-grid/flex-direction-page.tsx
@@ -53,7 +53,8 @@ const FlexColReverseExample: React.FC = () => {
 // ページコンポーネント本体
 const FlexDirectionPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Flex Direction (フレックス方向)';
+  const enTitle = 'Flexbox & Grid: Flex Direction ';
+const jaTitle = 'フレックス方向';
   const links = [
     {
       title: 'Tailwind CSS: Flex Direction',
@@ -99,7 +100,7 @@ const FlexDirectionPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Flex Direction - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/flex-grow-page.tsx
+++ b/src/pages/flexbox-grid/flex-grow-page.tsx
@@ -60,7 +60,8 @@ const GrowSpecificExample: React.FC = () => {
 // ページコンポーネント本体
 const FlexGrowPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Flex Grow (フレックス拡大係数)';
+  const enTitle = 'Flexbox & Grid: Flex Grow ';
+const jaTitle = 'フレックス拡大係数';
   const links = [
     {
       title: 'Tailwind CSS: Flex Grow',
@@ -96,7 +97,7 @@ const FlexGrowPage: React.FC = () => {
   `.trim(); // 任意の値を使用
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Flex Grow - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/flex-page.tsx
+++ b/src/pages/flexbox-grid/flex-page.tsx
@@ -77,7 +77,8 @@ const FlexNoneExample: React.FC = () => {
 // ページコンポーネント本体
 const FlexPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Flex (フレックス)';
+  const enTitle = 'Flexbox & Grid: Flex ';
+const jaTitle = 'フレックス';
   const links = [
     {
       title: 'Tailwind CSS: Flex',
@@ -120,7 +121,7 @@ const FlexPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Flex - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/flex-shrink-page.tsx
+++ b/src/pages/flexbox-grid/flex-shrink-page.tsx
@@ -68,7 +68,8 @@ const ShrinkSpecificExample: React.FC = () => {
 // ページコンポーネント本体
 const FlexShrinkPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Flex Shrink (フレックス縮小係数)';
+  const enTitle = 'Flexbox & Grid: Flex Shrink ';
+const jaTitle = 'フレックス縮小係数';
   const links = [
     {
       title: 'Tailwind CSS: Flex Shrink',
@@ -105,7 +106,7 @@ const FlexShrinkPage: React.FC = () => {
   `.trim(); // 任意の値を使用
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Flex Shrink - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/flex-wrap-page.tsx
+++ b/src/pages/flexbox-grid/flex-wrap-page.tsx
@@ -71,7 +71,8 @@ const FlexNoWrapExample: React.FC = () => {
 // ページコンポーネント本体
 const FlexWrapPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Flex Wrap (フレックス折り返し)';
+  const enTitle = 'Flexbox & Grid: Flex Wrap ';
+const jaTitle = 'フレックス折り返し';
   const links = [
     {
       title: 'Tailwind CSS: Flex Wrap',
@@ -112,7 +113,7 @@ const FlexWrapPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Flex Wrap - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/gap-page.tsx
+++ b/src/pages/flexbox-grid/gap-page.tsx
@@ -67,7 +67,8 @@ const FlexGapExample: React.FC = () => {
 // ページコンポーネント本体
 const GapPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Gap (溝)';
+  const enTitle = 'Flexbox & Grid: Gap ';
+const jaTitle = '溝';
   const links = [
     {
       title: 'Tailwind CSS: Gap',
@@ -113,7 +114,7 @@ const GapPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Gap - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/grid-auto-columns-page.tsx
+++ b/src/pages/flexbox-grid/grid-auto-columns-page.tsx
@@ -61,7 +61,8 @@ const AutoColsFrExample: React.FC = () => {
 // ページコンポーネント本体
 const GridAutoColumnsPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Grid Auto Columns (グリッド自動列サイズ)';
+  const enTitle = 'Flexbox & Grid: Grid Auto Columns ';
+const jaTitle = 'グリッド自動列サイズ';
   const links = [
     {
       title: 'Tailwind CSS: Grid Auto Columns',
@@ -104,7 +105,7 @@ const GridAutoColumnsPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Grid Auto Columns - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/grid-auto-flow-page.tsx
+++ b/src/pages/flexbox-grid/grid-auto-flow-page.tsx
@@ -75,7 +75,8 @@ const GridFlowColDenseExample: React.FC = () => {
 // ページコンポーネント本体
 const GridAutoFlowPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Grid Auto Flow (グリッド自動配置フロー)';
+  const enTitle = 'Flexbox & Grid: Grid Auto Flow ';
+const jaTitle = 'グリッド自動配置フロー';
   const links = [
     {
       title: 'Tailwind CSS: Grid Auto Flow',
@@ -122,7 +123,7 @@ const GridAutoFlowPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Grid Auto Flow - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/grid-auto-rows-page.tsx
+++ b/src/pages/flexbox-grid/grid-auto-rows-page.tsx
@@ -55,7 +55,8 @@ const AutoRowsFrExample: React.FC = () => {
 // ページコンポーネント本体
 const GridAutoRowsPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Grid Auto Rows (グリッド自動行サイズ)';
+  const enTitle = 'Flexbox & Grid: Grid Auto Rows ';
+const jaTitle = 'グリッド自動行サイズ';
   const links = [
     {
       title: 'Tailwind CSS: Grid Auto Rows',
@@ -98,7 +99,7 @@ const GridAutoRowsPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Grid Auto Rows - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/grid-column-page.tsx
+++ b/src/pages/flexbox-grid/grid-column-page.tsx
@@ -61,7 +61,8 @@ const ColFullExample: React.FC = () => {
 // ページコンポーネント本体
 const GridColumnPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Grid Column Start / End (グリッド列の開始/終了)';
+  const enTitle = 'Flexbox & Grid: Grid Column Start / End ';
+const jaTitle = 'グリッド列の開始/終了';
   const links = [
     {
       title: 'Tailwind CSS: Grid Column Start / End',
@@ -110,7 +111,7 @@ const GridColumnPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Grid Column - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/grid-row-page.tsx
+++ b/src/pages/flexbox-grid/grid-row-page.tsx
@@ -72,7 +72,8 @@ const RowFullExample: React.FC = () => {
 // ページコンポーネント本体
 const GridRowPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Grid Row Start / End (グリッド行の開始/終了)';
+  const enTitle = 'Flexbox & Grid: Grid Row Start / End ';
+const jaTitle = 'グリッド行の開始/終了';
   const links = [
     {
       title: 'Tailwind CSS: Grid Row Start / End',
@@ -122,7 +123,7 @@ const GridRowPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Grid Row - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/grid-template-columns-page.tsx
+++ b/src/pages/flexbox-grid/grid-template-columns-page.tsx
@@ -62,7 +62,8 @@ const ArbitraryColsExample: React.FC = () => {
 // ページコンポーネント本体
 const GridTemplateColumnsPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Grid Template Columns (グリッド列テンプレート)';
+  const enTitle = 'Flexbox & Grid: Grid Template Columns ';
+const jaTitle = 'グリッド列テンプレート';
   const links = [
     {
       title: 'Tailwind CSS: Grid Template Columns',
@@ -115,7 +116,7 @@ const GridTemplateColumnsPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Grid Template Columns - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/grid-template-rows-page.tsx
+++ b/src/pages/flexbox-grid/grid-template-rows-page.tsx
@@ -65,7 +65,8 @@ const ArbitraryRowsExample: React.FC = () => {
 // ページコンポーネント本体
 const GridTemplateRowsPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Grid Template Rows (グリッド行テンプレート)';
+  const enTitle = 'Flexbox & Grid: Grid Template Rows ';
+const jaTitle = 'グリッド行テンプレート';
   const links = [
     {
       title: 'Tailwind CSS: Grid Template Rows',
@@ -119,7 +120,7 @@ const GridTemplateRowsPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Grid Template Rows - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/justify-content-page.tsx
+++ b/src/pages/flexbox-grid/justify-content-page.tsx
@@ -94,7 +94,8 @@ const JustifyStretchExample: React.FC = () => {
 // ページコンポーネント本体
 const JustifyContentPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Justify Content (主軸方向の揃え)';
+  const enTitle = 'Flexbox & Grid: Justify Content ';
+const jaTitle = '主軸方向の揃え';
   const links = [
     {
       title: 'Tailwind CSS: Justify Content',
@@ -116,7 +117,7 @@ const JustifyContentPage: React.FC = () => {
   const justifyStretchHtml = `<div class="flex justify-stretch ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Justify Content - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/justify-items-page.tsx
+++ b/src/pages/flexbox-grid/justify-items-page.tsx
@@ -61,7 +61,8 @@ const JustifyItemsStretchExample: React.FC = () => {
 // ページコンポーネント本体
 const JustifyItemsPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Justify Items (アイテムのインライン軸揃え - Grid)';
+  const enTitle = 'Flexbox & Grid: Justify Items ';
+const jaTitle = 'アイテムのインライン軸揃え - Grid';
   const links = [
     {
       title: 'Tailwind CSS: Justify Items',
@@ -80,7 +81,7 @@ const JustifyItemsPage: React.FC = () => {
   const justifyStretchHtml = `<div class="grid justify-items-stretch ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Justify Items - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/justify-self-page.tsx
+++ b/src/pages/flexbox-grid/justify-self-page.tsx
@@ -27,7 +27,8 @@ const JustifySelfExample: React.FC = () => {
 // ページコンポーネント本体
 const JustifySelfPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Justify Self (個別アイテムのインライン軸揃え - Grid)';
+  const enTitle = 'Flexbox & Grid: Justify Self ';
+const jaTitle = '個別アイテムのインライン軸揃え - Grid';
   const links = [
     {
       title: 'Tailwind CSS: Justify Self',
@@ -47,7 +48,7 @@ const JustifySelfPage: React.FC = () => {
   // const justifySelfAutoHtml = `<div class="justify-self-auto ...">Item</div>`; // Usually same as stretch
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Justify Self - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/order-page.tsx
+++ b/src/pages/flexbox-grid/order-page.tsx
@@ -61,7 +61,8 @@ const OrderNoneExample: React.FC = () => {
 // ページコンポーネント本体
 const OrderPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Order (順序)';
+  const enTitle = 'Flexbox & Grid: Order ';
+const jaTitle = '順序';
   const links = [
     {
       title: 'Tailwind CSS: Order',
@@ -99,7 +100,7 @@ const OrderPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Order - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/place-content-page.tsx
+++ b/src/pages/flexbox-grid/place-content-page.tsx
@@ -96,7 +96,8 @@ const PlaceContentStretchExample: React.FC = () => {
 // ページコンポーネント本体
 const PlaceContentPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Place Content (複数行/列の揃えとスペース配分)';
+  const enTitle = 'Flexbox & Grid: Place Content ';
+const jaTitle = '複数行/列の揃えとスペース配分';
   const links = [
     {
       title: 'Tailwind CSS: Place Content',
@@ -118,7 +119,7 @@ const PlaceContentPage: React.FC = () => {
   const placeContentStretchHtml = `<div class="grid place-content-stretch h-48 ...">...</div>`; // v3.3+
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Place Content - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/place-items-page.tsx
+++ b/src/pages/flexbox-grid/place-items-page.tsx
@@ -58,7 +58,8 @@ const PlaceItemsStretchExample: React.FC = () => {
 // ページコンポーネント本体
 const PlaceItemsPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Place Items (アイテムの揃え - Grid)';
+  const enTitle = 'Flexbox & Grid: Place Items ';
+const jaTitle = 'アイテムの揃え - Grid';
   const links = [
     {
       title: 'Tailwind CSS: Place Items',
@@ -77,7 +78,7 @@ const PlaceItemsPage: React.FC = () => {
   const placeStretchHtml = `<div class="grid place-items-stretch h-32 ...">...</div>`; // Default
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Place Items - Tailwind CSS Cheatsheet</title>

--- a/src/pages/flexbox-grid/place-self-page.tsx
+++ b/src/pages/flexbox-grid/place-self-page.tsx
@@ -30,7 +30,8 @@ const PlaceSelfExample: React.FC = () => {
 const PlaceSelfPage: React.FC = () => {
   // ★修正: JustifySelfPage -> PlaceSelfPage
   // ArticleLayout に渡すデータ
-  const title = 'Flexbox & Grid: Place Self (個別アイテムの揃え - Grid)';
+  const enTitle = 'Flexbox & Grid: Place Self ';
+const jaTitle = '個別アイテムの揃え - Grid';
   const links = [
     {
       title: 'Tailwind CSS: Place Self',
@@ -50,7 +51,7 @@ const PlaceSelfPage: React.FC = () => {
   // const justifySelfAutoHtml = `<div class="justify-self-auto ...">Item</div>`; // Usually same as stretch
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Place Self - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/accent-color-page.tsx
+++ b/src/pages/interactivity/accent-color-page.tsx
@@ -57,7 +57,8 @@ const ArbitraryAccentColorExample: React.FC = () => {
 // ページコンポーネント本体
 const AccentColorPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: Accent Color (アクセントカラー)';
+  const enTitle = 'Interactivity: Accent Color ';
+const jaTitle = 'アクセントカラー';
   const links = [
     {
       title: 'Tailwind CSS: Accent Color',
@@ -83,7 +84,7 @@ const AccentColorPage: React.FC = () => {
   const arbitraryAccentColorHtml = `<input type="checkbox" checked class="accent-[#ff7f50] ...">`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Accent Color - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/appearance-page.tsx
+++ b/src/pages/interactivity/appearance-page.tsx
@@ -63,7 +63,8 @@ const AppearanceExample: React.FC = () => {
 // ページコンポーネント本体
 const AppearancePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: Appearance (外観)';
+  const enTitle = 'Interactivity: Appearance ';
+const jaTitle = '外観';
   const links = [
     {
       title: 'Tailwind CSS: Appearance',
@@ -95,7 +96,7 @@ const AppearancePage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Appearance - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/caret-color-page.tsx
+++ b/src/pages/interactivity/caret-color-page.tsx
@@ -88,7 +88,8 @@ const ArbitraryCaretColorExample: React.FC = () => {
 // ページコンポーネント本体
 const CaretColorPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: Caret Color (キャレットカラー)';
+  const enTitle = 'Interactivity: Caret Color ';
+const jaTitle = 'キャレットカラー';
   const links = [
     {
       title: 'Tailwind CSS: Caret Color',
@@ -120,7 +121,7 @@ const CaretColorPage: React.FC = () => {
   const arbitraryCaretColorHtml = `<input type="text" class="caret-[#ff7f50] ...">`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Caret Color - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/cursor-page.tsx
+++ b/src/pages/interactivity/cursor-page.tsx
@@ -122,7 +122,8 @@ const CursorExample: React.FC = () => {
 // ページコンポーネント本体
 const CursorPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: Cursor (カーソル)';
+  const enTitle = 'Interactivity: Cursor ';
+const jaTitle = 'カーソル';
   const links = [
     {
       title: 'Tailwind CSS: Cursor',
@@ -143,7 +144,7 @@ const CursorPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Cursor - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/pointer-events-page.tsx
+++ b/src/pages/interactivity/pointer-events-page.tsx
@@ -23,7 +23,8 @@ const PointerEventsExample: React.FC = () => {
 // ページコンポーネント本体
 const PointerEventsPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: Pointer Events (ポインターイベント)';
+  const enTitle = 'Interactivity: Pointer Events ';
+const jaTitle = 'ポインターイベント';
   const links = [
     {
       title: 'Tailwind CSS: Pointer Events',
@@ -51,7 +52,7 @@ const PointerEventsPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Pointer Events - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/resize-page.tsx
+++ b/src/pages/interactivity/resize-page.tsx
@@ -66,7 +66,8 @@ const ResizeExample: React.FC = () => {
 // ページコンポーネント本体
 const ResizePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: Resize (リサイズ)';
+  const enTitle = 'Interactivity: Resize ';
+const jaTitle = 'リサイズ';
   const links = [
     {
       title: 'Tailwind CSS: Resize',
@@ -94,7 +95,7 @@ const ResizePage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Resize - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/scroll-behavior-page.tsx
+++ b/src/pages/interactivity/scroll-behavior-page.tsx
@@ -85,7 +85,8 @@ const ScrollBehaviorExample: React.FC = () => {
 // ページコンポーネント本体
 const ScrollBehaviorPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: Scroll Behavior (スクロール動作)';
+  const enTitle = 'Interactivity: Scroll Behavior ';
+const jaTitle = 'スクロール動作';
   const links = [
     {
       title: 'Tailwind CSS: Scroll Behavior',
@@ -111,7 +112,7 @@ const ScrollBehaviorPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Scroll Behavior - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/scroll-margin-page.tsx
+++ b/src/pages/interactivity/scroll-margin-page.tsx
@@ -129,7 +129,8 @@ const ArbitraryScrollMarginExample: React.FC = () => {
 // ページコンポーネント本体
 const ScrollMarginPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: Scroll Margin (スクロールマージン)';
+  const enTitle = 'Interactivity: Scroll Margin ';
+const jaTitle = 'スクロールマージン';
   const links = [
     {
       title: 'Tailwind CSS: Scroll Margin',
@@ -160,7 +161,7 @@ const ScrollMarginPage: React.FC = () => {
   const arbitraryScrollMarginHtml = `<div id="section3" class="scroll-mt-[50px] ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Scroll Margin - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/scroll-padding-page.tsx
+++ b/src/pages/interactivity/scroll-padding-page.tsx
@@ -132,7 +132,8 @@ const ArbitraryScrollPaddingExample: React.FC = () => {
 // ページコンポーネント本体
 const ScrollPaddingPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: Scroll Padding (スクロールパディング)';
+  const enTitle = 'Interactivity: Scroll Padding ';
+const jaTitle = 'スクロールパディング';
   const links = [
     {
       title: 'Tailwind CSS: Scroll Padding',
@@ -163,7 +164,7 @@ const ScrollPaddingPage: React.FC = () => {
   const arbitraryScrollPaddingHtml = `<div class="scroll-pt-[60px] ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Scroll Padding - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/scroll-snap-align-page.tsx
+++ b/src/pages/interactivity/scroll-snap-align-page.tsx
@@ -98,7 +98,8 @@ const ScrollSnapAlignExample: React.FC = () => {
 // ページコンポーネント本体
 const ScrollSnapAlignPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: Scroll Snap Align (スクロールスナップ位置揃え)';
+  const enTitle = 'Interactivity: Scroll Snap Align ';
+const jaTitle = 'スクロールスナップ位置揃え';
   const links = [
     {
       title: 'Tailwind CSS: Scroll Snap Align',
@@ -121,7 +122,7 @@ const ScrollSnapAlignPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Scroll Snap Align - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/scroll-snap-stop-page.tsx
+++ b/src/pages/interactivity/scroll-snap-stop-page.tsx
@@ -59,7 +59,8 @@ const ScrollSnapStopExample: React.FC = () => {
 // ページコンポーネント本体
 const ScrollSnapStopPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: Scroll Snap Stop (スクロールスナップ停止)';
+  const enTitle = 'Interactivity: Scroll Snap Stop ';
+const jaTitle = 'スクロールスナップ停止';
   const links = [
     {
       title: 'Tailwind CSS: Scroll Snap Stop',
@@ -87,7 +88,7 @@ const ScrollSnapStopPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Scroll Snap Stop - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/scroll-snap-type-page.tsx
+++ b/src/pages/interactivity/scroll-snap-type-page.tsx
@@ -127,7 +127,8 @@ const ScrollSnapTypeExample: React.FC = () => {
 // ページコンポーネント本体
 const ScrollSnapTypePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: Scroll Snap Type (スクロールスナップタイプ)';
+  const enTitle = 'Interactivity: Scroll Snap Type ';
+const jaTitle = 'スクロールスナップタイプ';
   const links = [
     {
       title: 'Tailwind CSS: Scroll Snap Type',
@@ -161,7 +162,7 @@ const ScrollSnapTypePage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Scroll Snap Type - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/touch-action-page.tsx
+++ b/src/pages/interactivity/touch-action-page.tsx
@@ -93,7 +93,8 @@ const TouchActionExample: React.FC = () => {
 // ページコンポーネント本体
 const TouchActionPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: Touch Action (タッチ操作)';
+  const enTitle = 'Interactivity: Touch Action ';
+const jaTitle = 'タッチ操作';
   const links = [
     {
       title: 'Tailwind CSS: Touch Action',
@@ -127,7 +128,7 @@ const TouchActionPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Touch Action - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/user-select-page.tsx
+++ b/src/pages/interactivity/user-select-page.tsx
@@ -40,7 +40,8 @@ const UserSelectExample: React.FC = () => {
 // ページコンポーネント本体
 const UserSelectPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: User Select (ユーザー選択)';
+  const enTitle = 'Interactivity: User Select ';
+const jaTitle = 'ユーザー選択';
   const links = [
     {
       title: 'Tailwind CSS: User Select',
@@ -68,7 +69,7 @@ const UserSelectPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>User Select - Tailwind CSS Cheatsheet</title>

--- a/src/pages/interactivity/will-change-page.tsx
+++ b/src/pages/interactivity/will-change-page.tsx
@@ -59,7 +59,8 @@ const WillChangeExample: React.FC = () => {
 // ページコンポーネント本体
 const WillChangePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Interactivity: Will Change (変更予測)';
+  const enTitle = 'Interactivity: Will Change ';
+const jaTitle = '変更予測';
   const links = [
     {
       title: 'Tailwind CSS: Will Change',
@@ -87,7 +88,7 @@ const WillChangePage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Will Change - Tailwind CSS Cheatsheet</title>

--- a/src/pages/sizing/height-page.tsx
+++ b/src/pages/sizing/height-page.tsx
@@ -97,7 +97,8 @@ const HeightMinMaxAutoFitExample: React.FC = () => {
 // ページコンポーネント本体
 const HeightPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Sizing: Height (高さ)';
+  const enTitle = 'Sizing: Height ';
+const jaTitle = '高さ';
   const links = [
     {
       title: 'Tailwind CSS: Height',
@@ -121,7 +122,7 @@ const HeightPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Height - Tailwind CSS Cheatsheet</title>

--- a/src/pages/sizing/max-height-page.tsx
+++ b/src/pages/sizing/max-height-page.tsx
@@ -120,7 +120,8 @@ const MaxHMinMaxFitExample: React.FC = () => {
 // ページコンポーネント本体
 const MaxHeightPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Sizing: Max-Height (最大高さ)';
+  const enTitle = 'Sizing: Max-Height ';
+const jaTitle = '最大高さ';
   const links = [
     {
       title: 'Tailwind CSS: Max-Height',
@@ -144,7 +145,7 @@ const MaxHeightPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Max Height - Tailwind CSS Cheatsheet</title>

--- a/src/pages/sizing/max-width-page.tsx
+++ b/src/pages/sizing/max-width-page.tsx
@@ -71,7 +71,8 @@ const MaxWProseExample: React.FC = () => {
 // ページコンポーネント本体
 const MaxWidthPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Sizing: Max-Width (最大幅)';
+  const enTitle = 'Sizing: Max-Width ';
+const jaTitle = '最大幅';
   const links = [
     {
       title: 'Tailwind CSS: Max-Width',
@@ -95,7 +96,7 @@ const MaxWidthPage: React.FC = () => {
   const maxWProseHtml = `<div class="max-w-prose ...">...</div>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Max Width - Tailwind CSS Cheatsheet</title>

--- a/src/pages/sizing/min-height-page.tsx
+++ b/src/pages/sizing/min-height-page.tsx
@@ -73,7 +73,8 @@ const MinHMinMaxFitExample: React.FC = () => {
 // ページコンポーネント本体
 const MinHeightPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Sizing: Min-Height (最小高さ)';
+  const enTitle = 'Sizing: Min-Height ';
+const jaTitle = '最小高さ';
   const links = [
     {
       title: 'Tailwind CSS: Min-Height',
@@ -96,7 +97,7 @@ const MinHeightPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Min Height - Tailwind CSS Cheatsheet</title>

--- a/src/pages/sizing/min-width-page.tsx
+++ b/src/pages/sizing/min-width-page.tsx
@@ -64,7 +64,8 @@ const MinWFitExample: React.FC = () => {
 // ページコンポーネント本体
 const MinWidthPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Sizing: Min-Width (最小幅)';
+  const enTitle = 'Sizing: Min-Width ';
+const jaTitle = '最小幅';
   const links = [
     {
       title: 'Tailwind CSS: Min-Width',
@@ -84,7 +85,7 @@ const MinWidthPage: React.FC = () => {
   const minWFitHtml = `<div class="min-w-fit ...">...</div>`; // v3.3+
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Min Width - Tailwind CSS Cheatsheet</title>

--- a/src/pages/sizing/size-page.tsx
+++ b/src/pages/sizing/size-page.tsx
@@ -81,7 +81,8 @@ const SizeFullExample: React.FC = () => {
 // ページコンポーネント本体
 const SizePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Sizing: Size (サイズ - 幅と高さ)';
+  const enTitle = 'Sizing: Size ';
+const jaTitle = 'サイズ - 幅と高さ';
   const links = [
     {
       title: 'Tailwind CSS: Size (v3.3+)',
@@ -109,7 +110,7 @@ const SizePage: React.FC = () => {
   const sizeFullHtml = `<div class="size-full ...">...</div>`; // Requires parent size
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Size - Tailwind CSS Cheatsheet</title>

--- a/src/pages/sizing/width-page.tsx
+++ b/src/pages/sizing/width-page.tsx
@@ -87,7 +87,8 @@ const WidthFitExample: React.FC = () => {
 // ページコンポーネント本体
 const WidthPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Sizing: Width (幅)';
+  const enTitle = 'Sizing: Width ';
+const jaTitle = '幅';
   const links = [
     {
       title: 'Tailwind CSS: Width',
@@ -111,7 +112,7 @@ const WidthPage: React.FC = () => {
   const wFitHtml = `<div class="w-fit ...">Fit</div>`; // v3.0+
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Width - Tailwind CSS Cheatsheet</title>

--- a/src/pages/spacing/margin-page.tsx
+++ b/src/pages/spacing/margin-page.tsx
@@ -103,7 +103,8 @@ const NegativeMarginExample: React.FC = () => {
 // ページコンポーネント本体
 const MarginPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Spacing: Margin (マージン)';
+  const enTitle = 'Spacing: Margin ';
+const jaTitle = 'マージン';
   const links = [
     {
       title: 'Tailwind CSS: Margin',
@@ -125,7 +126,7 @@ const MarginPage: React.FC = () => {
   const mNegativeHtml = `<div class="-m-4 ...">...</div>`; // 負のマージン
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Margin - Tailwind CSS Cheatsheet</title>

--- a/src/pages/spacing/padding-page.tsx
+++ b/src/pages/spacing/padding-page.tsx
@@ -53,7 +53,8 @@ const PaddingLogicalExample: React.FC = () => {
 // ページコンポーネント本体
 const PaddingPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Spacing: Padding (パディング)';
+  const enTitle = 'Spacing: Padding ';
+const jaTitle = 'パディング';
   const links = [
     {
       title: 'Tailwind CSS: Padding',
@@ -73,7 +74,7 @@ const PaddingPage: React.FC = () => {
   const pLogicalHtml = `<div class="ps-8 pe-4 ...">...</div>`; // v3.3+
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Padding - Tailwind CSS Cheatsheet</title>

--- a/src/pages/spacing/space-between-page.tsx
+++ b/src/pages/spacing/space-between-page.tsx
@@ -54,7 +54,8 @@ const NegativeSpaceExample: React.FC = () => {
 // ページコンポーネント本体
 const SpaceBetweenPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Spacing: Space Between (要素間のスペース)';
+  const enTitle = 'Spacing: Space Between ';
+const jaTitle = '要素間のスペース';
   const links = [
     {
       title: 'Tailwind CSS: Space Between',
@@ -97,7 +98,7 @@ const SpaceBetweenPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Space Between - Tailwind CSS Cheatsheet</title>

--- a/src/pages/svg/fill-page.tsx
+++ b/src/pages/svg/fill-page.tsx
@@ -40,7 +40,8 @@ const ArbitraryFillExample: React.FC = () => {
 // ページコンポーネント本体
 const FillPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'SVG: Fill (塗りつぶし)';
+  const enTitle = 'SVG: Fill ';
+const jaTitle = '塗りつぶし';
   const links = [
     {
       title: 'Tailwind CSS: Fill',
@@ -67,7 +68,7 @@ const FillPage: React.FC = () => {
   const arbitraryFillHtml = `<svg class="fill-[#ff7f50] ...">...</svg>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Fill - Tailwind CSS Cheatsheet</title>

--- a/src/pages/svg/stroke-page.tsx
+++ b/src/pages/svg/stroke-page.tsx
@@ -40,7 +40,8 @@ const ArbitraryStrokeExample: React.FC = () => {
 // ページコンポーネント本体
 const StrokePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'SVG: Stroke (線)';
+  const enTitle = 'SVG: Stroke ';
+const jaTitle = '線';
   const links = [
     {
       title: 'Tailwind CSS: Stroke',
@@ -67,7 +68,7 @@ const StrokePage: React.FC = () => {
   const arbitraryStrokeHtml = `<svg class="stroke-[#ff7f50] fill-none stroke-2 ...">...</svg>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Stroke - Tailwind CSS Cheatsheet</title>

--- a/src/pages/svg/stroke-width-page.tsx
+++ b/src/pages/svg/stroke-width-page.tsx
@@ -39,7 +39,8 @@ const ArbitraryStrokeWidthExample: React.FC = () => {
 // ページコンポーネント本体
 const StrokeWidthPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'SVG: Stroke Width (線の太さ)';
+  const enTitle = 'SVG: Stroke Width ';
+const jaTitle = '線の太さ';
   const links = [
     {
       title: 'Tailwind CSS: Stroke Width',
@@ -61,7 +62,7 @@ const StrokeWidthPage: React.FC = () => {
   const arbitraryStrokeWidthHtml = `<svg class="stroke-[3] ...">...</svg>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Stroke Width - Tailwind CSS Cheatsheet</title>

--- a/src/pages/tables/border-collapse-page.tsx
+++ b/src/pages/tables/border-collapse-page.tsx
@@ -69,7 +69,8 @@ const BorderCollapseExample: React.FC = () => {
 // ページコンポーネント本体
 const BorderCollapsePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Tables: Border Collapse (境界線の結合/分離)';
+  const enTitle = 'Tables: Border Collapse ';
+const jaTitle = '境界線の結合/分離';
   const links = [
     {
       title: 'Tailwind CSS: Border Collapse',
@@ -119,7 +120,7 @@ const BorderCollapsePage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Border Collapse - Tailwind CSS Cheatsheet</title>

--- a/src/pages/tables/border-spacing-page.tsx
+++ b/src/pages/tables/border-spacing-page.tsx
@@ -79,7 +79,8 @@ const ArbitraryBorderSpacingExample: React.FC = () => {
 // ページコンポーネント本体
 const BorderSpacingPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Tables: Border Spacing (境界線の間隔)';
+  const enTitle = 'Tables: Border Spacing ';
+const jaTitle = '境界線の間隔';
   const links = [
     {
       title: 'Tailwind CSS: Border Spacing',
@@ -107,7 +108,7 @@ const BorderSpacingPage: React.FC = () => {
   const arbitraryBorderSpacingHtml = `<table class="border-separate border-spacing-[10px] ..."> ... </table>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Border Spacing - Tailwind CSS Cheatsheet</title>

--- a/src/pages/tables/caption-side-page.tsx
+++ b/src/pages/tables/caption-side-page.tsx
@@ -56,7 +56,8 @@ const CaptionSideExample: React.FC = () => {
 // ページコンポーネント本体
 const CaptionSidePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Tables: Caption Side (キャプションの位置)';
+  const enTitle = 'Tables: Caption Side ';
+const jaTitle = 'キャプションの位置';
   const links = [
     {
       title: 'Tailwind CSS: Caption Side',
@@ -94,7 +95,7 @@ const CaptionSidePage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Caption Side - Tailwind CSS Cheatsheet</title>

--- a/src/pages/tables/table-layout-page.tsx
+++ b/src/pages/tables/table-layout-page.tsx
@@ -67,7 +67,8 @@ const TableLayoutExample: React.FC = () => {
 // ページコンポーネント本体
 const TableLayoutPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Tables: Table Layout (テーブルレイアウト)';
+  const enTitle = 'Tables: Table Layout ';
+const jaTitle = 'テーブルレイアウト';
   const links = [
     {
       title: 'Tailwind CSS: Table Layout',
@@ -117,7 +118,7 @@ const TableLayoutPage: React.FC = () => {
   `.trim();
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Table Layout - Tailwind CSS Cheatsheet</title>

--- a/src/pages/transforms/rotate-page.tsx
+++ b/src/pages/transforms/rotate-page.tsx
@@ -63,7 +63,8 @@ const ArbitraryRotateExample: React.FC = () => {
 // ページコンポーネント本体
 const RotatePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Transforms: Rotate (回転)';
+  const enTitle = 'Transforms: Rotate ';
+const jaTitle = '回転';
   const links = [
     {
       title: 'Tailwind CSS: Rotate',
@@ -87,7 +88,7 @@ const RotatePage: React.FC = () => {
   const arbitraryRotateHtml = `<img class="rotate-[22.5deg] ..." src="...">`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Rotate - Tailwind CSS Cheatsheet</title>

--- a/src/pages/transforms/scale-page.tsx
+++ b/src/pages/transforms/scale-page.tsx
@@ -88,7 +88,8 @@ const ArbitraryScaleExample: React.FC = () => {
 // ページコンポーネント本体
 const ScalePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Transforms: Scale (拡大縮小)';
+  const enTitle = 'Transforms: Scale ';
+const jaTitle = '拡大縮小';
   const links = [
     {
       title: 'Tailwind CSS: Scale',
@@ -115,7 +116,7 @@ const ScalePage: React.FC = () => {
   const arbitraryScaleHtml = `<img class="scale-[1.75] ..." src="...">`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Scale - Tailwind CSS Cheatsheet</title>

--- a/src/pages/transforms/skew-page.tsx
+++ b/src/pages/transforms/skew-page.tsx
@@ -63,7 +63,8 @@ const ArbitrarySkewExample: React.FC = () => {
 // ページコンポーネント本体
 const SkewPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Transforms: Skew (傾斜)';
+  const enTitle = 'Transforms: Skew ';
+const jaTitle = '傾斜';
   const links = [
     {
       title: 'Tailwind CSS: Skew',
@@ -95,7 +96,7 @@ const SkewPage: React.FC = () => {
   const arbitrarySkewHtml = `<img class="skew-x-[15deg] ..." src="...">`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Skew - Tailwind CSS Cheatsheet</title>

--- a/src/pages/transforms/transform-origin-page.tsx
+++ b/src/pages/transforms/transform-origin-page.tsx
@@ -47,7 +47,8 @@ const ArbitraryTransformOriginExample: React.FC = () => {
 // ページコンポーネント本体
 const TransformOriginPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Transforms: Transform Origin (変形の原点)';
+  const enTitle = 'Transforms: Transform Origin ';
+const jaTitle = '変形の原点';
   const links = [
     {
       title: 'Tailwind CSS: Transform Origin',
@@ -72,7 +73,7 @@ const TransformOriginPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Transform Origin - Tailwind CSS Cheatsheet</title>

--- a/src/pages/transforms/translate-page.tsx
+++ b/src/pages/transforms/translate-page.tsx
@@ -38,7 +38,8 @@ const ArbitraryTranslateExample: React.FC = () => {
 // ページコンポーネント本体
 const TranslatePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Transforms: Translate (移動)';
+  const enTitle = 'Transforms: Translate ';
+const jaTitle = '移動';
   const links = [
     {
       title: 'Tailwind CSS: Translate',
@@ -67,7 +68,7 @@ const TranslatePage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Translate - Tailwind CSS Cheatsheet</title>

--- a/src/pages/transitions-animation/animation-page.tsx
+++ b/src/pages/transitions-animation/animation-page.tsx
@@ -69,7 +69,8 @@ const AnimationExample: React.FC = () => {
 // ページコンポーネント本体
 const AnimationPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Transitions & Animation: Animation (アニメーション)';
+  const enTitle = 'Transitions & Animation: Animation ';
+const jaTitle = 'アニメーション';
   const links = [
     {
       title: 'Tailwind CSS: Animation',
@@ -106,7 +107,7 @@ const AnimationPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Animation - Tailwind CSS Cheatsheet</title>

--- a/src/pages/transitions-animation/transition-delay-page.tsx
+++ b/src/pages/transitions-animation/transition-delay-page.tsx
@@ -38,7 +38,8 @@ const ArbitraryTransitionDelayExample: React.FC = () => {
 // ページコンポーネント本体
 const TransitionDelayPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Transitions & Animation: Transition Delay (トランジション遅延)';
+  const enTitle = 'Transitions & Animation: Transition Delay ';
+const jaTitle = 'トランジション遅延';
   const links = [
     {
       title: 'Tailwind CSS: Transition Delay',
@@ -66,7 +67,7 @@ const TransitionDelayPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Transition Delay - Tailwind CSS Cheatsheet</title>

--- a/src/pages/transitions-animation/transition-duration-page.tsx
+++ b/src/pages/transitions-animation/transition-duration-page.tsx
@@ -38,7 +38,8 @@ const ArbitraryTransitionDurationExample: React.FC = () => {
 // ページコンポーネント本体
 const TransitionDurationPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Transitions & Animation: Transition Duration (トランジション時間)';
+  const enTitle = 'Transitions & Animation: Transition Duration ';
+const jaTitle = 'トランジション時間';
   const links = [
     {
       title: 'Tailwind CSS: Transition Duration',
@@ -66,7 +67,7 @@ const TransitionDurationPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Transition Duration - Tailwind CSS Cheatsheet</title>

--- a/src/pages/transitions-animation/transition-property-page.tsx
+++ b/src/pages/transitions-animation/transition-property-page.tsx
@@ -50,7 +50,8 @@ const ArbitraryTransitionPropertyExample: React.FC = () => {
 // ページコンポーネント本体
 const TransitionPropertyPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Transitions & Animation: Transition Property (トランジション対象プロパティ)';
+  const enTitle = 'Transitions & Animation: Transition Property ';
+const jaTitle = 'トランジション対象プロパティ';
   const links = [
     {
       title: 'Tailwind CSS: Transition Property',
@@ -81,7 +82,7 @@ const TransitionPropertyPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Transition Property - Tailwind CSS Cheatsheet</title>

--- a/src/pages/transitions-animation/transition-timing-function-page.tsx
+++ b/src/pages/transitions-animation/transition-timing-function-page.tsx
@@ -45,7 +45,8 @@ const ArbitraryTransitionTimingFunctionExample: React.FC = () => {
 // ページコンポーネント本体
 const TransitionTimingFunctionPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Transitions & Animation: Transition Timing Function (イージング関数)';
+  const enTitle = 'Transitions & Animation: Transition Timing Function ';
+const jaTitle = 'イージング関数';
   const links = [
     {
       title: 'Tailwind CSS: Transition Timing Function',
@@ -76,7 +77,7 @@ const TransitionTimingFunctionPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Transition Timing Function - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/content-page.tsx
+++ b/src/pages/typography/content-page.tsx
@@ -59,7 +59,8 @@ const ContentStringExample: React.FC = () => {
 // ページコンポーネント本体
 const ContentPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Content (コンテンツ)';
+  const enTitle = 'Typography: Content ';
+const jaTitle = 'コンテンツ';
   const links = [
     {
       title: 'Tailwind CSS: Content (v3.0+)',
@@ -87,7 +88,7 @@ const ContentPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Content - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/font-family-page.tsx
+++ b/src/pages/typography/font-family-page.tsx
@@ -19,7 +19,8 @@ const FontMonoExample: React.FC = () => {
 // ページコンポーネント本体
 const FontFamilyPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Font Family (フォントファミリー)';
+  const enTitle = 'Typography: Font Family ';
+const jaTitle = 'フォントファミリー';
   const links = [
     {
       title: 'Tailwind CSS: Font Family',
@@ -51,7 +52,7 @@ module.exports = {
   const customFontHtml = `<p class="font-display ...">カスタムディスプレイフォント</p>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Font Family - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/font-size-page.tsx
+++ b/src/pages/typography/font-size-page.tsx
@@ -30,7 +30,8 @@ const ArbitrarySizeExample: React.FC = () => {
 // ページコンポーネント本体
 const FontSizePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Font Size (フォントサイズ)';
+  const enTitle = 'Typography: Font Size ';
+const jaTitle = 'フォントサイズ';
   const links = [
     {
       title: 'Tailwind CSS: Font Size',
@@ -55,7 +56,7 @@ const FontSizePage: React.FC = () => {
   const arbitrarySizeHtml = `<p class="text-[22px] leading-[30px] ...">...</p>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Font Size - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/font-smoothing-page.tsx
+++ b/src/pages/typography/font-smoothing-page.tsx
@@ -24,7 +24,8 @@ const SubpixelAntialiasedExample: React.FC = () => {
 // ページコンポーネント本体
 const FontSmoothingPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Font Smoothing (フォントスムージング)';
+  const enTitle = 'Typography: Font Smoothing ';
+const jaTitle = 'フォントスムージング';
   const links = [
     {
       title: 'Tailwind CSS: Font Smoothing',
@@ -50,7 +51,7 @@ const FontSmoothingPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Font Smoothing - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/font-style-page.tsx
+++ b/src/pages/typography/font-style-page.tsx
@@ -24,7 +24,8 @@ const NotItalicExample: React.FC = () => {
 // ページコンポーネント本体
 const FontStylePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Font Style (フォントスタイル)';
+  const enTitle = 'Typography: Font Style ';
+const jaTitle = 'フォントスタイル';
   const links = [
     {
       title: 'Tailwind CSS: Font Style',
@@ -42,7 +43,7 @@ const FontStylePage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Font Style - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/font-variant-numeric-page.tsx
+++ b/src/pages/typography/font-variant-numeric-page.tsx
@@ -45,7 +45,8 @@ const StackedFractionsExample: React.FC = () => {
 // ページコンポーネント本体
 const FontVariantNumericPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Font Variant Numeric (数字・分数の字形)';
+  const enTitle = 'Typography: Font Variant Numeric ';
+const jaTitle = '数字・分数の字形';
   const links = [
     {
       title: 'Tailwind CSS: Font Variant Numeric',
@@ -65,7 +66,7 @@ const FontVariantNumericPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Font Variant Numeric - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/font-weight-page.tsx
+++ b/src/pages/typography/font-weight-page.tsx
@@ -24,7 +24,8 @@ const FontWeightExample: React.FC = () => {
 // ページコンポーネント本体
 const FontWeightPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Font Weight (フォントの太さ)';
+  const enTitle = 'Typography: Font Weight ';
+const jaTitle = 'フォントの太さ';
   const links = [
     {
       title: 'Tailwind CSS: Font Weight',
@@ -49,7 +50,7 @@ const FontWeightPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Font Weight - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/hyphens-page.tsx
+++ b/src/pages/typography/hyphens-page.tsx
@@ -40,7 +40,8 @@ const HyphensAutoExample: React.FC = () => {
 // ページコンポーネント本体
 const HyphensPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Hyphens (ハイフネーション)';
+  const enTitle = 'Typography: Hyphens ';
+const jaTitle = 'ハイフネーション';
   const links = [
     {
       title: 'Tailwind CSS: Hyphens',
@@ -59,7 +60,7 @@ const HyphensPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Hyphens - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/letter-spacing-page.tsx
+++ b/src/pages/typography/letter-spacing-page.tsx
@@ -27,7 +27,8 @@ const ArbitraryTrackingExample: React.FC = () => {
 // ページコンポーネント本体
 const LetterSpacingPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Letter Spacing (文字間隔)';
+  const enTitle = 'Typography: Letter Spacing ';
+const jaTitle = '文字間隔';
   const links = [
     {
       title: 'Tailwind CSS: Letter Spacing',
@@ -53,7 +54,7 @@ const LetterSpacingPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Letter Spacing - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/line-clamp-page.tsx
+++ b/src/pages/typography/line-clamp-page.tsx
@@ -27,7 +27,8 @@ const LineClampExample: React.FC = () => {
 // ページコンポーネント本体
 const LineClampPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Line Clamp (行数制限)';
+  const enTitle = 'Typography: Line Clamp ';
+const jaTitle = '行数制限';
   const links = [
     {
       title: '@tailwindcss/line-clamp Plugin',
@@ -52,7 +53,7 @@ const LineClampPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Line Clamp - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/line-height-page.tsx
+++ b/src/pages/typography/line-height-page.tsx
@@ -45,7 +45,8 @@ const ArbitraryLeadingExample: React.FC = () => {
 // ページコンポーネント本体
 const LineHeightPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Line Height (行の高さ)';
+  const enTitle = 'Typography: Line Height ';
+const jaTitle = '行の高さ';
   const links = [
     {
       title: 'Tailwind CSS: Line Height',
@@ -75,7 +76,7 @@ const LineHeightPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Line Height - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/list-style-image-page.tsx
+++ b/src/pages/typography/list-style-image-page.tsx
@@ -33,7 +33,8 @@ const ListImageCustomExample: React.FC = () => {
 // ページコンポーネント本体
 const ListStyleImagePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: List Style Image (リストマーカー画像)';
+  const enTitle = 'Typography: List Style Image ';
+const jaTitle = 'リストマーカー画像';
   const links = [
     {
       title: 'Tailwind CSS: List Style Image (v3.3+)',
@@ -50,7 +51,7 @@ const ListStyleImagePage: React.FC = () => {
   const listImageCustomHtml = `<ul class="list-image-[url('/img/check.svg')] list-inside ...">...</ul>`; // カスタム値
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>List Style Image - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/list-style-position-page.tsx
+++ b/src/pages/typography/list-style-position-page.tsx
@@ -28,7 +28,8 @@ const ListOutsideExample: React.FC = () => {
 // ページコンポーネント本体
 const ListStylePositionPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: List Style Position (リストマーカー位置)';
+  const enTitle = 'Typography: List Style Position ';
+const jaTitle = 'リストマーカー位置';
   const links = [
     {
       title: 'Tailwind CSS: List Style Position',
@@ -46,7 +47,7 @@ const ListStylePositionPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>List Style Position - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/list-style-type-page.tsx
+++ b/src/pages/typography/list-style-type-page.tsx
@@ -35,7 +35,8 @@ const ListDecimalExample: React.FC = () => {
 // ページコンポーネント本体
 const ListStyleTypePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: List Style Type (リストマーカーの種類)';
+  const enTitle = 'Typography: List Style Type ';
+const jaTitle = 'リストマーカーの種類';
   const links = [
     {
       title: 'Tailwind CSS: List Style Type',
@@ -54,7 +55,7 @@ const ListStyleTypePage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>List Style Type - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/text-align-page.tsx
+++ b/src/pages/typography/text-align-page.tsx
@@ -54,7 +54,8 @@ const TextAlignStartEndExample: React.FC = () => {
 // ページコンポーネント本体
 const TextAlignPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Text Align (テキスト揃え)';
+  const enTitle = 'Typography: Text Align ';
+const jaTitle = 'テキスト揃え';
   const links = [
     {
       title: 'Tailwind CSS: Text Align',
@@ -78,7 +79,7 @@ const TextAlignPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Text Align - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/text-color-page.tsx
+++ b/src/pages/typography/text-color-page.tsx
@@ -56,7 +56,8 @@ const ArbitraryColorExample: React.FC = () => {
 // ページコンポーネント本体
 const TextColorPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Text Color (テキストの色)';
+  const enTitle = 'Typography: Text Color ';
+const jaTitle = 'テキストの色';
   const links = [
     {
       title: 'Tailwind CSS: Text Color',
@@ -91,7 +92,7 @@ const TextColorPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Text Color - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/text-decoration-color-page.tsx
+++ b/src/pages/typography/text-decoration-color-page.tsx
@@ -37,7 +37,8 @@ const DecorationCurrentInheritTransparentExample: React.FC = () => {
 // ページコンポーネント本体
 const TextDecorationColorPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Text Decoration Color (テキスト装飾線の色)';
+  const enTitle = 'Typography: Text Decoration Color ';
+const jaTitle = 'テキスト装飾線の色';
   const links = [
     {
       title: 'Tailwind CSS: Text Decoration Color',
@@ -63,7 +64,7 @@ const TextDecorationColorPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Text Decoration Color - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/text-decoration-page.tsx
+++ b/src/pages/typography/text-decoration-page.tsx
@@ -42,7 +42,8 @@ const NoUnderlineExample: React.FC = () => {
 // ページコンポーネント本体
 const TextDecorationPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Text Decoration (テキスト装飾線)';
+  const enTitle = 'Typography: Text Decoration ';
+const jaTitle = 'テキスト装飾線';
   const links = [
     {
       title: 'Tailwind CSS: Text Decoration',
@@ -66,7 +67,7 @@ const TextDecorationPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Text Decoration - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/text-decoration-style-page.tsx
+++ b/src/pages/typography/text-decoration-style-page.tsx
@@ -48,7 +48,8 @@ const DecorationWavyExample: React.FC = () => {
 // ページコンポーネント本体
 const TextDecorationStylePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Text Decoration Style (テキスト装飾線のスタイル)';
+  const enTitle = 'Typography: Text Decoration Style ';
+const jaTitle = 'テキスト装飾線のスタイル';
   const links = [
     {
       title: 'Tailwind CSS: Text Decoration Style',
@@ -69,7 +70,7 @@ const TextDecorationStylePage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Text Decoration Style - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/text-decoration-thickness-page.tsx
+++ b/src/pages/typography/text-decoration-thickness-page.tsx
@@ -28,7 +28,8 @@ const ArbitraryThicknessExample: React.FC = () => {
 // ページコンポーネント本体
 const TextDecorationThicknessPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Text Decoration Thickness (テキスト装飾線の太さ)';
+  const enTitle = 'Typography: Text Decoration Thickness ';
+const jaTitle = 'テキスト装飾線の太さ';
   const links = [
     {
       title: 'Tailwind CSS: Text Decoration Thickness',
@@ -54,7 +55,7 @@ const TextDecorationThicknessPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Text Decoration Thickness - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/text-indent-page.tsx
+++ b/src/pages/typography/text-indent-page.tsx
@@ -40,7 +40,8 @@ const ArbitraryIndentExample: React.FC = () => {
 // ページコンポーネント本体
 const TextIndentPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Text Indent (テキストインデント)';
+  const enTitle = 'Typography: Text Indent ';
+const jaTitle = 'テキストインデント';
   const links = [
     {
       title: 'Tailwind CSS: Text Indent',
@@ -62,7 +63,7 @@ const TextIndentPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Text Indent - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/text-overflow-page.tsx
+++ b/src/pages/typography/text-overflow-page.tsx
@@ -39,7 +39,8 @@ const TextClipExample: React.FC = () => {
 // ページコンポーネント本体
 const TextOverflowPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Text Overflow (テキストオーバーフロー)';
+  const enTitle = 'Typography: Text Overflow ';
+const jaTitle = 'テキストオーバーフロー';
   const links = [
     {
       title: 'Tailwind CSS: Text Overflow',
@@ -58,7 +59,7 @@ const TextOverflowPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Text Overflow - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/text-transform-page.tsx
+++ b/src/pages/typography/text-transform-page.tsx
@@ -41,7 +41,8 @@ const NormalCaseExample: React.FC = () => {
 // ページコンポーネント本体
 const TextTransformPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Text Transform (テキスト変換)';
+  const enTitle = 'Typography: Text Transform ';
+const jaTitle = 'テキスト変換';
   const links = [
     {
       title: 'Tailwind CSS: Text Transform',
@@ -61,7 +62,7 @@ const TextTransformPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Text Transform - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/text-underline-offset-page.tsx
+++ b/src/pages/typography/text-underline-offset-page.tsx
@@ -27,7 +27,8 @@ const ArbitraryOffsetExample: React.FC = () => {
 // ページコンポーネント本体
 const TextUnderlineOffsetPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Text Underline Offset (下線のオフセット)';
+  const enTitle = 'Typography: Text Underline Offset ';
+const jaTitle = '下線のオフセット';
   const links = [
     {
       title: 'Tailwind CSS: Text Underline Offset',
@@ -52,7 +53,7 @@ const TextUnderlineOffsetPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Text Underline Offset - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/text-wrap-page.tsx
+++ b/src/pages/typography/text-wrap-page.tsx
@@ -44,7 +44,8 @@ const TextBalanceExample: React.FC = () => {
 // ページコンポーネント本体
 const TextWrapPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Text Wrap (テキスト折り返し)';
+  const enTitle = 'Typography: Text Wrap ';
+const jaTitle = 'テキスト折り返し';
   const links = [
     {
       title: 'Tailwind CSS: Text Wrap (v3.3+)',
@@ -67,7 +68,7 @@ const TextWrapPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Text Wrap - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/vertical-align-page.tsx
+++ b/src/pages/typography/vertical-align-page.tsx
@@ -96,7 +96,8 @@ const AlignSuperExample: React.FC = () => {
 // ページコンポーネント本体
 const VerticalAlignPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Vertical Align (垂直方向の揃え)';
+  const enTitle = 'Typography: Vertical Align ';
+const jaTitle = '垂直方向の揃え';
   const links = [
     {
       title: 'Tailwind CSS: Vertical Align',
@@ -119,7 +120,7 @@ const VerticalAlignPage: React.FC = () => {
   const alignSuperHtml = `<span class="align-super ...">...</span>`;
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Vertical Align - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/whitespace-page.tsx
+++ b/src/pages/typography/whitespace-page.tsx
@@ -78,7 +78,8 @@ Whitespace Break Spaces (v3.0+):
 // ページコンポーネント本体
 const WhitespacePage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Whitespace (空白文字の扱い)';
+  const enTitle = 'Typography: Whitespace ';
+const jaTitle = '空白文字の扱い';
   const links = [
     {
       title: 'Tailwind CSS: Whitespace',
@@ -104,7 +105,7 @@ const WhitespacePage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Whitespace - Tailwind CSS Cheatsheet</title>

--- a/src/pages/typography/word-break-page.tsx
+++ b/src/pages/typography/word-break-page.tsx
@@ -52,7 +52,8 @@ const BreakKeepExample: React.FC = () => {
 // ページコンポーネント本体
 const WordBreakPage: React.FC = () => {
   // ArticleLayout に渡すデータ
-  const title = 'Typography: Word Break (単語の改行)';
+  const enTitle = 'Typography: Word Break ';
+const jaTitle = '単語の改行';
   const links = [
     {
       title: 'Tailwind CSS: Word Break',
@@ -80,7 +81,7 @@ const WordBreakPage: React.FC = () => {
 
 
   return (
-    <ArticleLayout title={title} links={links}>
+    <ArticleLayout enTitle={enTitle} jaTitle={jaTitle} links={links}>
 
       <Helmet>
         <title>Word Break - Tailwind CSS Cheatsheet</title>


### PR DESCRIPTION
Modify ArticleLayout to accept enTitle and jaTitle props instead of title.
    Update all page components under src/pages to define enTitle and jaTitle separately and pass them to ArticleLayout.
    This allows displaying page titles in both English and Japanese.